### PR TITLE
feat: support @easy-shadcn namespace for registry

### DIFF
--- a/content/docs/components/async-button.mdx
+++ b/content/docs/components/async-button.mdx
@@ -2,11 +2,19 @@
 title: Async Button
 ---
 
-AsyncButton 基于 shadcn 的 `Button` 扩展，当 `onClick` 返回 `Promise` 时自动接管 loading 状态，期间按钮会被禁用并覆盖一个 spinner。也支持通过 `loading` prop 受控。
+AsyncButton extends shadcn's `Button`: when `onClick` returns a `Promise`, the component automatically manages the loading state — the button is disabled and a spinner overlay is shown until the promise settles. You can also drive the loading state manually via the `loading` prop.
 
 <ExamplePreview name="async-button-demo" />
 
 ## Installation
+
+With the [`@easy-shadcn` namespace](/docs/installation) configured:
+
+```shell
+pnpm dlx shadcn@latest add @easy-shadcn/async-button
+```
+
+Or install via the full URL (zero configuration):
 
 ```shell
 pnpm dlx shadcn@latest add https://easy-shadcn.vercel.app/r/async-button.json
@@ -14,15 +22,15 @@ pnpm dlx shadcn@latest add https://easy-shadcn.vercel.app/r/async-button.json
 
 ## Props
 
-| Prop       | Type                                                          | Default | Description                                                           |
-| ---------- | ------------------------------------------------------------- | ------- | --------------------------------------------------------------------- |
-| `onClick`  | `(e: MouseEvent<HTMLButtonElement>) => void \| Promise<void>` | -       | 点击回调。返回 Promise 时，自动进入 loading 状态直到 Promise settle。 |
-| `loading`  | `boolean`                                                     | `false` | 受控 loading 状态，与内部 async loading 取或。                        |
-| `disabled` | `boolean`                                                     | `false` | 禁用按钮。loading 时按钮也会被自动禁用。                              |
+| Prop       | Type                                                          | Default | Description                                                                                     |
+| ---------- | ------------------------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------- |
+| `onClick`  | `(e: MouseEvent<HTMLButtonElement>) => void \| Promise<void>` | -       | Click handler. When it returns a Promise, the button enters the loading state until it settles. |
+| `loading`  | `boolean`                                                     | `false` | Controlled loading state, OR-ed with the internal async loading state.                          |
+| `disabled` | `boolean`                                                     | `false` | Disables the button. The button is also disabled automatically while loading.                   |
 
-其余 props（`variant` / `size` / `className` 等）继承自 shadcn `Button`，会直接透传。
+All other props (`variant`, `size`, `className`, etc.) are inherited from shadcn's `Button` and forwarded as-is.
 
 ## Notes
 
-- `onClick` 抛出的异常会被捕获并通过 `console.error` 打印，避免未处理的 Promise rejection 打断页面，同时保留可观测性。
-- Loading overlay 使用 `bg-current/10` + `backdrop-blur-[1px]`，颜色随按钮前景色自适应，适配所有 variant。
+- Exceptions thrown from `onClick` are caught and logged via `console.error` so that unhandled promise rejections don't break the page, while still surfacing the error for observability.
+- The loading overlay uses `bg-current/10` + `backdrop-blur-[1px]`, so its color follows the button's foreground color and works with every variant.

--- a/content/docs/components/card.mdx
+++ b/content/docs/components/card.mdx
@@ -6,6 +6,14 @@ title: Card
 
 ## Installation
 
+With the [`@easy-shadcn` namespace](/docs/installation) configured:
+
+```shell
+pnpm dlx shadcn@latest add @easy-shadcn/card
+```
+
+Or install via the full URL (zero configuration):
+
 ```shell
 pnpm dlx shadcn@latest add https://easy-shadcn.vercel.app/r/card.json
 ```

--- a/content/docs/components/modal.mdx
+++ b/content/docs/components/modal.mdx
@@ -2,6 +2,24 @@
 title: Modal
 ---
 
+## Installation
+
+With the [`@easy-shadcn` namespace](/docs/installation) configured:
+
+```shell
+pnpm dlx shadcn@latest add @easy-shadcn/modal
+```
+
+Or install via the full URL (zero configuration):
+
+```shell
+pnpm dlx shadcn@latest add https://easy-shadcn.vercel.app/r/modal.json
+```
+
+The internal `@easy-shadcn/async-button` dependency is installed automatically alongside `modal`.
+
+## Usage
+
 Add Provider to App
 
 <ExamplePreview name="modal-provider-demo" />

--- a/content/docs/components/tabs.mdx
+++ b/content/docs/components/tabs.mdx
@@ -6,6 +6,14 @@ title: Tabs
 
 ## Installation
 
+With the [`@easy-shadcn` namespace](/docs/installation) configured:
+
+```shell
+pnpm dlx shadcn@latest add @easy-shadcn/tabs
+```
+
+Or install via the full URL (zero configuration):
+
 ```shell
 pnpm dlx shadcn@latest add https://easy-shadcn.vercel.app/r/tabs.json
 ```

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -8,6 +8,10 @@ Make it as simple and convenient as a component library to use shadcn-ui and enh
 Of course, you can also fork this repository to create your own component library,
 or directly copy certain component codes into your own project.
 
+## Getting Started
+
+See the [Installation](/docs/installation) guide to configure the `@easy-shadcn` registry namespace, then install any component with a single command.
+
 ## The difference with shadcn/ui
 
 - Simplify the use of components and reduce the large amount of boilerplate code brought by integrated components. Use the props of each part to transmit. (Although this is not the best practice, it is simple)

--- a/content/docs/installation.mdx
+++ b/content/docs/installation.mdx
@@ -1,0 +1,57 @@
+---
+title: Installation
+description: Configure the @easy-shadcn registry and install components.
+---
+
+easy-shadcn components are distributed through the shadcn CLI. You can install them in two ways:
+
+- **Recommended**: Configure the `@easy-shadcn` namespace once, then install any component with a short command.
+- **Quick try**: Install directly via the full JSON URL — no configuration required.
+
+## Recommended: Configure the `@easy-shadcn` Namespace
+
+Add a `registries` entry to your project's `components.json`:
+
+```json title="components.json"
+{
+  "registries": {
+    "@easy-shadcn": "https://easy-shadcn.vercel.app/r/{name}.json"
+  }
+}
+```
+
+Then install any component using the namespace form:
+
+```shell
+pnpm dlx shadcn@latest add @easy-shadcn/card
+pnpm dlx shadcn@latest add @easy-shadcn/modal
+```
+
+Cross-component dependencies (for example, `modal` depends on `async-button`) are resolved automatically through the same namespace — you don't need to install them by hand.
+
+### One-liner to patch `components.json`
+
+If you'd rather not edit the file manually, run this command once at your project root:
+
+```shell
+node -e 'const f="components.json",fs=require("fs"),c=JSON.parse(fs.readFileSync(f,"utf8"));c.registries={...c.registries,"@easy-shadcn":"https://easy-shadcn.vercel.app/r/{name}.json"};fs.writeFileSync(f,JSON.stringify(c,null,2)+"\n")'
+```
+
+## Alternative: Install via Full URL
+
+You can skip the namespace config entirely and pass the JSON URL to the shadcn CLI:
+
+```shell
+pnpm dlx shadcn@latest add https://easy-shadcn.vercel.app/r/card.json
+pnpm dlx shadcn@latest add https://easy-shadcn.vercel.app/r/modal.json
+```
+
+Zero configuration, but you'll need to type the full URL every time.
+
+## Why Namespaced?
+
+- **Unambiguous**: `@easy-shadcn/card` clearly comes from this registry and won't be confused with shadcn's built-in `card`.
+- **Clean dependencies**: Registry items can declare internal dependencies like `@easy-shadcn/async-button`, and the CLI resolves them through the namespace mapping.
+- **Short commands**: Once configured, the install experience matches the official shadcn flow.
+
+> `@easy-shadcn` is **not** a globally registered namespace — it's just a local alias in your `components.json` that points to this registry's URL template. You can rename the alias, but the registry's internal `registryDependencies` declare `@easy-shadcn/...`, so renaming it requires updating those references too. Keeping the default is recommended.

--- a/public/r/modal.json
+++ b/public/r/modal.json
@@ -9,7 +9,7 @@
   "registryDependencies": [
     "dialog",
     "alert-dialog",
-    "async-button"
+    "@easy-shadcn/async-button"
   ],
   "files": [
     {

--- a/public/r/registry.json
+++ b/public/r/registry.json
@@ -50,7 +50,7 @@
       "type": "registry:component",
       "title": "Integrated Modal",
       "description": "Composable Modal and AlertModal built on shadcn base-ui Dialog / AlertDialog, plus imperative alert / confirm helpers powered by @easy-shadcn/command-modal.",
-      "registryDependencies": ["dialog", "alert-dialog", "async-button"],
+      "registryDependencies": ["dialog", "alert-dialog", "@easy-shadcn/async-button"],
       "dependencies": ["@easy-shadcn/command-modal"],
       "files": [
         {

--- a/registry.json
+++ b/registry.json
@@ -50,7 +50,7 @@
       "type": "registry:component",
       "title": "Integrated Modal",
       "description": "Composable Modal and AlertModal built on shadcn base-ui Dialog / AlertDialog, plus imperative alert / confirm helpers powered by @easy-shadcn/command-modal.",
-      "registryDependencies": ["dialog", "alert-dialog", "async-button"],
+      "registryDependencies": ["dialog", "alert-dialog", "@easy-shadcn/async-button"],
       "dependencies": ["@easy-shadcn/command-modal"],
       "files": [
         {


### PR DESCRIPTION
Switch internal registry dependencies to the @easy-shadcn/<name> form so consumers can resolve them unambiguously, and document the namespace setup alongside the existing full-URL install flow.