### PR TITLE
feat(select): hover-clear, maxCount and contextual right-side icon

### DIFF
--- a/registry/hooks/use-select-items.ts
+++ b/registry/hooks/use-select-items.ts
@@ -14,14 +14,12 @@ export interface SelectItem {
 export interface UseSelectItemsOptions {
   filter?: (item: SelectItem, query: string) => boolean;
   items: SelectItem[];
-  value?: string | string[] | null;
 }
 
 export interface UseSelectItemsReturn {
   filterFn: (itemValue: string, query: string) => boolean;
   findItem: (value: string) => SelectItem | undefined;
   itemToStringLabel: (value: string) => string;
-  selectedItems: SelectItem[];
   stringItems: string[];
 }
 
@@ -37,30 +35,34 @@ function labelToString(label: ReactNode, fallback: string): string {
 
 export function useSelectItems({
   items,
-  value,
   filter,
 }: UseSelectItemsOptions): UseSelectItemsReturn {
+  const index = useMemo(() => {
+    const map = new Map<string, SelectItem>();
+    for (const item of items) {
+      map.set(item.value, item);
+    }
+    return map;
+  }, [items]);
+
   const stringItems = useMemo(() => items.map((i) => i.value), [items]);
 
-  const findItem = useCallback(
-    (v: string) => items.find((i) => i.value === v),
-    [items]
-  );
+  const findItem = useCallback((v: string) => index.get(v), [index]);
 
   const itemToStringLabel = useCallback(
     (v: string): string => {
-      const item = findItem(v);
+      const item = index.get(v);
       if (!item) {
         return v;
       }
       return labelToString(item.label, v);
     },
-    [findItem]
+    [index]
   );
 
   const filterFn = useCallback(
     (itemValue: string, query: string): boolean => {
-      const item = findItem(itemValue);
+      const item = index.get(itemValue);
       if (!item) {
         return true;
       }
@@ -70,29 +72,13 @@ export function useSelectItems({
       const labelStr = labelToString(item.label, item.value).toLowerCase();
       return labelStr.includes(query.toLowerCase());
     },
-    [findItem, filter]
+    [index, filter]
   );
-
-  const selectedItems = useMemo(() => {
-    if (value === null || value === undefined) {
-      return [];
-    }
-    const arr = Array.isArray(value) ? value : [value];
-    const result: SelectItem[] = [];
-    for (const v of arr) {
-      const item = findItem(v);
-      if (item) {
-        result.push(item);
-      }
-    }
-    return result;
-  }, [value, findItem]);
 
   return {
     stringItems,
     findItem,
     itemToStringLabel,
     filterFn,
-    selectedItems,
   };
 }

--- a/registry/hooks/use-select-loader.ts
+++ b/registry/hooks/use-select-loader.ts
@@ -107,13 +107,13 @@ export function useSelectLoader({
     if (!enabled || serverSideFilter) {
       return;
     }
-    if (loadOn === "mount") {
-      fetchItems("");
+    if (hasLoadedRef.current) {
       return;
     }
-    if (open && !hasLoadedRef.current) {
-      fetchItems("");
+    if (loadOn === "open" && !open) {
+      return;
     }
+    fetchItems("");
   }, [enabled, serverSideFilter, loadOn, open, fetchItems]);
 
   // Server-side filter mode: fetch on open + on every query change (debounced).
@@ -169,11 +169,15 @@ export function useSelectLoader({
     if (arr.length === 0) {
       return;
     }
+    const itemIndex = new Map<string, SelectItem>();
+    for (const item of items) {
+      itemIndex.set(item.value, item);
+    }
     setSelectedCache((prev) => {
       let changed = false;
       const next = new Map(prev);
       for (const v of arr) {
-        const found = items.find((i) => i.value === v);
+        const found = itemIndex.get(v);
         if (found && next.get(v) !== found) {
           next.set(v, found);
           changed = true;

--- a/registry/ui/select.tsx
+++ b/registry/ui/select.tsx
@@ -1,8 +1,15 @@
 "use client";
 
+import { Combobox as ComboboxPrimitive } from "@base-ui/react";
+import {
+  ArrowDown01Icon,
+  Cancel01Icon,
+  SearchList01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import type { ClassValue } from "clsx";
-import type { ReactNode } from "react";
-import { useCallback, useState } from "react";
+import type { FocusEvent, ReactNode } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Combobox,
@@ -11,13 +18,16 @@ import {
   ComboboxChipsInput,
   ComboboxContent,
   ComboboxEmpty,
-  ComboboxInput,
   ComboboxItem,
   ComboboxList,
-  ComboboxTrigger,
   ComboboxValue,
   useComboboxAnchor,
 } from "@/components/ui/combobox";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@/components/ui/input-group";
 import { cn } from "@/lib/utils";
 import type { SelectItem } from "@/registry/hooks/use-select-items";
 import { useSelectItems } from "@/registry/hooks/use-select-items";
@@ -32,7 +42,10 @@ export interface SelectProps {
   chipClassName?: ClassValue;
   /** Root wrapper className. */
   className?: ClassValue;
-  /** Show a clear button. Single (non-multiple) modes only. */
+  /**
+   * Show an inline clear button when the field has a value and the user hovers
+   * the right-side icon area. Works in all three modes.
+   */
   clearable?: boolean;
   /** Popover content className. */
   contentClassName?: ClassValue;
@@ -98,13 +111,23 @@ export interface SelectProps {
    * - `"open"`: fire the first time the popup opens.
    */
   loadOn?: "mount" | "open";
+  /**
+   * Max selectable count in `multiple` mode. When the limit is reached every
+   * unselected item is rendered as `disabled` so the user cannot exceed it.
+   * Already-selected items stay clickable for deselection. Ignored in single mode.
+   */
+  maxCount?: number;
   /** Enable multi-select with chips. */
   multiple?: boolean;
   /** Form field name for native form submission. */
   name?: string;
   /** Called when the popover open state changes. */
   onOpenChange?: (open: boolean) => void;
-  /** Called when the selection changes. `undefined` indicates the value was cleared. */
+  /**
+   * Called when the selection changes.
+   * - Single mode: `string` when a value is selected, `undefined` when cleared.
+   * - Multi mode: `string[]` — an empty array represents no selection.
+   */
   onValueChange?: (value: string | string[] | undefined) => void;
   /** Controlled popover open state. */
   open?: boolean;
@@ -126,6 +149,8 @@ export interface SelectProps {
   value?: string | string[];
 }
 
+const ITEM_PRESS_REASON = "item-press";
+
 function defaultErrorRenderer(error: unknown): ReactNode {
   if (error instanceof Error && error.message) {
     return error.message;
@@ -142,6 +167,94 @@ function defaultErrorRenderer(error: unknown): ReactNode {
   return "Failed to load options";
 }
 
+function useAdornmentState() {
+  const [hovered, setHovered] = useState(false);
+  const [focused, setFocused] = useState(false);
+  const hoverHandlers = {
+    onMouseEnter: () => setHovered(true),
+    onMouseLeave: () => setHovered(false),
+  };
+  const focusHandlers = {
+    onBlurCapture: (e: FocusEvent<HTMLElement>) => {
+      if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+        setFocused(false);
+      }
+    },
+    onFocusCapture: () => setFocused(true),
+  };
+  return { focusHandlers, focused, hoverHandlers, hovered };
+}
+
+type AdornmentKind = "clear" | "search" | "down";
+
+function resolveAdornment({
+  canSearch,
+  clearable,
+  focused,
+  hasValue,
+  hovered,
+}: {
+  canSearch: boolean;
+  clearable: boolean;
+  focused: boolean;
+  hasValue: boolean;
+  hovered: boolean;
+}): AdornmentKind {
+  if (clearable && hasValue && hovered) {
+    return "clear";
+  }
+  if (canSearch && focused) {
+    return "search";
+  }
+  return "down";
+}
+
+function Spinner() {
+  return (
+    <span
+      aria-hidden
+      className="inline-block size-4 animate-spin rounded-full border-2 border-current border-r-transparent text-muted-foreground"
+    />
+  );
+}
+
+function StaticIcon({ icon }: { icon: typeof ArrowDown01Icon }) {
+  return (
+    <HugeiconsIcon
+      aria-hidden
+      className="pointer-events-none size-4 text-muted-foreground"
+      icon={icon}
+      strokeWidth={2}
+    />
+  );
+}
+
+function ClearButton({ className }: { className?: ClassValue }) {
+  return (
+    <ComboboxPrimitive.Clear
+      aria-label="Clear"
+      className={cn(
+        "size-4 cursor-pointer text-muted-foreground transition-colors hover:text-foreground",
+        className
+      )}
+      data-slot="combobox-clear"
+      render={
+        <HugeiconsIcon icon={Cancel01Icon} role="button" strokeWidth={2} />
+      }
+    />
+  );
+}
+
+function Adornment({ kind }: { kind: AdornmentKind }) {
+  if (kind === "clear") {
+    return <ClearButton />;
+  }
+  if (kind === "search") {
+    return <StaticIcon icon={SearchList01Icon} />;
+  }
+  return <StaticIcon icon={ArrowDown01Icon} />;
+}
+
 export const Select = ({
   items,
   loadItems,
@@ -156,6 +269,7 @@ export const Select = ({
   multiple = false,
   searchable = false,
   clearable = false,
+  maxCount,
   placeholder = "Select…",
   emptyMessage = "No results",
   disabled,
@@ -174,6 +288,7 @@ export const Select = ({
 }: SelectProps) => {
   const isAsync = Boolean(loadItems);
   const effectiveSearchable = searchable || (isAsync && serverSideFilter);
+  const hasInput = multiple || effectiveSearchable;
 
   const [internalOpen, setInternalOpen] = useState<boolean>(
     defaultOpen ?? false
@@ -191,13 +306,31 @@ export const Select = ({
     [isOpenControlled, onOpenChange]
   );
 
+  // Mirror selection so adornment/maxCount work for uncontrolled usage too.
+  const [internalValue, setInternalValue] = useState<
+    string | string[] | undefined
+  >(defaultValue);
+  const isValueControlled = value !== undefined;
+  const currentValue = isValueControlled ? value : internalValue;
+
+  const handleValueChange = useCallback(
+    (next: string | string[] | null | undefined) => {
+      const normalized = next ?? undefined;
+      if (!isValueControlled) {
+        setInternalValue(normalized);
+      }
+      onValueChange?.(normalized);
+    },
+    [isValueControlled, onValueChange]
+  );
+
   const [inputValue, setInputValue] = useState<string>("");
   const [query, setQuery] = useState<string>("");
 
   const handleInputValueChange = useCallback(
     (next: string, details: { reason: string }) => {
       setInputValue(next);
-      if (details.reason !== "item-press") {
+      if (details.reason !== ITEM_PRESS_REASON) {
         setQuery(next);
       }
     },
@@ -211,26 +344,27 @@ export const Select = ({
     enabled: asyncEnabled,
     refresh,
   } = useSelectLoader({
+    debounceMs,
     loadItems,
     loadOn,
-    serverSideFilter,
-    debounceMs,
     open: currentOpen,
     query,
-    value,
+    serverSideFilter,
+    value: currentValue,
   });
 
   const resolvedItems = asyncEnabled ? asyncItems : (items ?? []);
 
   const { stringItems, findItem, itemToStringLabel, filterFn } = useSelectItems(
     {
-      items: resolvedItems,
-      value,
       filter,
+      items: resolvedItems,
     }
   );
 
   const anchorRef = useComboboxAnchor();
+  const { hovered, focused, hoverHandlers, focusHandlers } =
+    useAdornmentState();
 
   const renderError = useCallback(
     (e: unknown): ReactNode => {
@@ -245,6 +379,32 @@ export const Select = ({
     [errorMessage]
   );
 
+  const valueArr = useMemo(() => {
+    if (currentValue === undefined) {
+      return [];
+    }
+    return Array.isArray(currentValue) ? currentValue : [currentValue];
+  }, [currentValue]);
+
+  const adornmentKind = resolveAdornment({
+    canSearch: hasInput,
+    clearable,
+    focused,
+    hasValue: valueArr.length > 0,
+    hovered,
+  });
+
+  // multi-only: when at limit, mark every unselected item as disabled.
+  const maxReached =
+    multiple &&
+    typeof maxCount === "number" &&
+    maxCount > 0 &&
+    valueArr.length >= maxCount;
+  const selectedSet = useMemo(
+    () => (maxReached ? new Set(valueArr) : null),
+    [maxReached, valueArr]
+  );
+
   const statusContent = (() => {
     if (asyncLoading) {
       return (
@@ -252,10 +412,7 @@ export const Select = ({
           className="flex items-center justify-center gap-2 px-2 py-3 text-muted-foreground text-sm"
           data-slot="combobox-status"
         >
-          <span
-            aria-hidden
-            className="inline-block size-3 animate-spin rounded-full border border-current border-r-transparent"
-          />
+          <Spinner />
           <span>{loadingMessage}</span>
         </div>
       );
@@ -289,10 +446,12 @@ export const Select = ({
         if (!item) {
           return null;
         }
+        const disabledByMax =
+          selectedSet !== null && !selectedSet.has(itemValue);
         return (
           <ComboboxItem
             className={cn(itemClassName, item.itemClassName)}
-            disabled={item.disabled}
+            disabled={item.disabled || disabledByMax}
             key={itemValue}
             value={itemValue}
           >
@@ -307,20 +466,18 @@ export const Select = ({
     <ComboboxEmpty className={cn(emptyClassName)}>{emptyMessage}</ComboboxEmpty>
   );
 
+  // Keep list mounted across loading/error so base-ui keeps collection state.
+  const showEmpty = !(asyncLoading || asyncError);
   const popupBody = (
     <>
       {statusContent}
-      {!(asyncLoading || asyncError) && (
-        <>
-          {list}
-          {empty}
-        </>
-      )}
+      {list}
+      {showEmpty && empty}
     </>
   );
 
   const sharedRootProps = {
-    defaultOpen,
+    defaultOpen: isOpenControlled ? undefined : defaultOpen,
     disabled,
     filter: serverSideFilter ? null : filterFn,
     inputValue,
@@ -338,10 +495,11 @@ export const Select = ({
         {...sharedRootProps}
         defaultValue={defaultValue as string[] | undefined}
         multiple
-        onValueChange={(next) => onValueChange?.(next ?? undefined)}
+        onValueChange={handleValueChange}
         value={value as string[] | undefined}
       >
         <ComboboxChips
+          {...focusHandlers}
           className={cn(triggerClassName, className)}
           ref={anchorRef}
         >
@@ -357,12 +515,18 @@ export const Select = ({
                   );
                 })}
                 <ComboboxChipsInput
-                  className={cn(inputClassName)}
+                  className={cn("flex-1", inputClassName)}
                   placeholder={values.length === 0 ? placeholder : undefined}
                 />
               </>
             )}
           </ComboboxValue>
+          <span
+            {...hoverHandlers}
+            className="ml-auto inline-flex shrink-0 items-center pl-1"
+          >
+            <Adornment kind={adornmentKind} />
+          </span>
         </ComboboxChips>
         <ComboboxContent anchor={anchorRef} className={cn(contentClassName)}>
           {popupBody}
@@ -376,15 +540,23 @@ export const Select = ({
       <Combobox<string, false>
         {...sharedRootProps}
         defaultValue={defaultValue as string | undefined}
-        onValueChange={(next) => onValueChange?.(next ?? undefined)}
+        onValueChange={handleValueChange}
         value={value as string | undefined}
       >
-        <ComboboxInput
-          className={cn(triggerClassName, inputClassName, className)}
-          disabled={disabled}
-          placeholder={placeholder}
-          showClear={clearable}
-        />
+        <InputGroup
+          {...focusHandlers}
+          className={cn("w-auto", triggerClassName, className)}
+        >
+          <ComboboxPrimitive.Input
+            className={cn(inputClassName)}
+            disabled={disabled}
+            placeholder={placeholder}
+            render={<InputGroupInput />}
+          />
+          <InputGroupAddon {...hoverHandlers} align="inline-end">
+            <Adornment kind={adornmentKind} />
+          </InputGroupAddon>
+        </InputGroup>
         <ComboboxContent className={cn(contentClassName)}>
           {popupBody}
         </ComboboxContent>
@@ -392,28 +564,44 @@ export const Select = ({
     );
   }
 
+  // Trigger is a <button>; nesting another <button> (clear) is invalid HTML,
+  // so the clear button rides above as an absolute-positioned sibling.
   return (
     <Combobox<string, false>
       {...sharedRootProps}
       defaultValue={defaultValue as string | undefined}
-      onValueChange={(next) => onValueChange?.(next ?? undefined)}
+      onValueChange={handleValueChange}
       value={value as string | undefined}
     >
-      <ComboboxTrigger
-        className={cn("justify-between", className, triggerClassName)}
-        disabled={disabled}
-        render={<Button variant="outline" />}
-      >
-        <ComboboxValue placeholder={placeholder}>
-          {(selected: string | null) => {
-            if (!selected) {
-              return placeholder;
-            }
-            const item = findItem(selected);
-            return <span className="truncate">{item?.label ?? selected}</span>;
-          }}
-        </ComboboxValue>
-      </ComboboxTrigger>
+      <div {...focusHandlers} className={cn("relative", className)}>
+        <ComboboxPrimitive.Trigger
+          className={cn(
+            "w-full justify-between pr-9 [&_svg:not([class*='size-'])]:size-4",
+            triggerClassName
+          )}
+          data-slot="combobox-trigger"
+          disabled={disabled}
+          render={<Button variant="outline" />}
+        >
+          <ComboboxValue placeholder={placeholder}>
+            {(selected: string | null) => {
+              if (!selected) {
+                return placeholder;
+              }
+              const item = findItem(selected);
+              return (
+                <span className="truncate">{item?.label ?? selected}</span>
+              );
+            }}
+          </ComboboxValue>
+        </ComboboxPrimitive.Trigger>
+        <span
+          {...hoverHandlers}
+          className="absolute top-1/2 right-2 inline-flex -translate-y-1/2 items-center"
+        >
+          <Adornment kind={adornmentKind} />
+        </span>
+      </div>
       <ComboboxContent className={cn(contentClassName)}>
         {popupBody}
       </ComboboxContent>


### PR DESCRIPTION
- Right-side icon switches by state: Clear (hover icon area with value) >
  Search (input focus) > ArrowDown (default). Clear/Search are mutually
  exclusive with the popup's own loading spinner.
- New maxCount prop for multi mode disables unselected items at limit.
- clearable extended to all three modes; trigger single uses an absolute sibling since <button> cannot nest another <button>.
- Mirror selection state so adornment / maxCount work uncontrolled too.
- Bug fix in useSelectLoader: loadOn="mount" no longer refetches every time the popup opens/closes (hasLoadedRef guard hoisted).
- Perf: useSelectItems findItem and useSelectLoader selectedCache use Map index instead of Array.find.
- Keep ComboboxList mounted across loading/error so base-ui retains its collection/highlight state across server-side filter cycles.