### PR TITLE
feat(table): add Table with selection, row click, a11y dev warns

### DIFF
--- a/components/examples/index.tsx
+++ b/components/examples/index.tsx
@@ -5,756 +5,101 @@ import React from "react";
 export default {
   "async-button-demo": {
     component: React.lazy(() => import("./async-button-demo")),
-    codeString: `"use client";
-
-import {
-  ArrowRightIcon,
-  DownloadIcon,
-  RefreshCwIcon,
-  SendIcon,
-  Trash2Icon,
-} from "lucide-react";
-import { AsyncButton } from "@/registry/ui/async-button";
-
-const wait = (ms: number) =>
-  new Promise<void>((resolve) => {
-    setTimeout(() => {
-      resolve();
-    }, ms);
-  });
-
-const Demo = () => (
-  <div className="flex flex-col gap-6">
-    <div className="flex flex-col gap-2">
-      <p className="text-muted-foreground text-sm">
-        Click the button — loading state activates automatically while the
-        promise is pending.
-      </p>
-      <div className="flex flex-wrap items-center gap-2">
-        <AsyncButton onClick={() => wait(2000)}>Submit Order</AsyncButton>
-        <AsyncButton onClick={() => wait(2000)} variant="outline">
-          Sync Data
-        </AsyncButton>
-        <AsyncButton onClick={() => wait(2000)} variant="secondary">
-          Export Report
-        </AsyncButton>
-      </div>
-    </div>
-
-    <div className="flex flex-col gap-2">
-      <p className="text-muted-foreground text-sm">
-        Drive loading externally via the <code>loading</code> prop.
-      </p>
-      <div className="flex flex-wrap items-center gap-2">
-        <AsyncButton loading>Controlled Loading</AsyncButton>
-      </div>
-    </div>
-
-    <div className="flex flex-col gap-2">
-      <p className="text-muted-foreground text-sm">
-        Use <code>startIcon</code> / <code>endIcon</code>. While loading, the
-        icon slot is swapped for the spinner — no overlay needed. When both are
-        present, <code>startIcon</code> takes the spinner.
-      </p>
-      <div className="flex flex-wrap items-center gap-2">
-        <AsyncButton onClick={() => wait(2000)} startIcon={<SendIcon />}>
-          Send Message
-        </AsyncButton>
-        <AsyncButton
-          endIcon={<ArrowRightIcon />}
-          onClick={() => wait(2000)}
-          variant="outline"
-        >
-          Continue
-        </AsyncButton>
-        <AsyncButton
-          endIcon={<ArrowRightIcon />}
-          onClick={() => wait(2000)}
-          startIcon={<DownloadIcon />}
-          variant="secondary"
-        >
-          Download &amp; Next
-        </AsyncButton>
-      </div>
-    </div>
-
-    <div className="flex flex-col gap-2">
-      <p className="text-muted-foreground text-sm">
-        Icon buttons with <code>size="icon"</code>.
-      </p>
-      <div className="flex flex-wrap items-center gap-2">
-        <AsyncButton onClick={() => wait(2000)} size="icon">
-          <SendIcon />
-        </AsyncButton>
-        <AsyncButton onClick={() => wait(2000)} size="icon" variant="outline">
-          <RefreshCwIcon />
-        </AsyncButton>
-        <AsyncButton
-          onClick={() => wait(2000)}
-          size="icon"
-          variant="destructive"
-        >
-          <Trash2Icon />
-        </AsyncButton>
-      </div>
-    </div>
-
-    <div className="flex flex-col gap-2">
-      <p className="text-muted-foreground text-sm">
-        Anti-flash: a 50ms task still shows the spinner for at least 200ms (the
-        default <code>minDuration</code>), so the indicator never just flickers
-        past.
-      </p>
-      <div className="flex flex-wrap items-center gap-2">
-        <AsyncButton onClick={() => wait(50)}>Fast Save (50ms)</AsyncButton>
-      </div>
-    </div>
-
-    <div className="flex flex-col gap-2">
-      <p className="text-muted-foreground text-sm">
-        Errors are caught and logged — the button recovers gracefully.
-      </p>
-      <div className="flex flex-wrap items-center gap-2">
-        <AsyncButton
-          onClick={() =>
-            wait(1500).then(() => {
-              throw new Error("Request failed");
-            })
-          }
-          variant="destructive"
-        >
-          Simulate Failure
-        </AsyncButton>
-      </div>
-    </div>
-  </div>
-);
-
-export default Demo;
-`
+    codeString: "\"use client\";\n\nimport {\n  ArrowRightIcon,\n  DownloadIcon,\n  RefreshCwIcon,\n  SendIcon,\n  Trash2Icon,\n} from \"lucide-react\";\nimport { AsyncButton } from \"@/registry/ui/async-button\";\n\nconst wait = (ms: number) =>\n  new Promise<void>((resolve) => {\n    setTimeout(() => {\n      resolve();\n    }, ms);\n  });\n\nconst Demo = () => (\n  <div className=\"flex flex-col gap-6\">\n    <div className=\"flex flex-col gap-2\">\n      <p className=\"text-muted-foreground text-sm\">\n        Click the button — loading state activates automatically while the\n        promise is pending.\n      </p>\n      <div className=\"flex flex-wrap items-center gap-2\">\n        <AsyncButton onClick={() => wait(2000)}>Submit Order</AsyncButton>\n        <AsyncButton onClick={() => wait(2000)} variant=\"outline\">\n          Sync Data\n        </AsyncButton>\n        <AsyncButton onClick={() => wait(2000)} variant=\"secondary\">\n          Export Report\n        </AsyncButton>\n      </div>\n    </div>\n\n    <div className=\"flex flex-col gap-2\">\n      <p className=\"text-muted-foreground text-sm\">\n        Drive loading externally via the <code>loading</code> prop.\n      </p>\n      <div className=\"flex flex-wrap items-center gap-2\">\n        <AsyncButton loading>Controlled Loading</AsyncButton>\n      </div>\n    </div>\n\n    <div className=\"flex flex-col gap-2\">\n      <p className=\"text-muted-foreground text-sm\">\n        Use <code>startIcon</code> / <code>endIcon</code>. While loading, the\n        icon slot is swapped for the spinner — no overlay needed. When both are\n        present, <code>startIcon</code> takes the spinner.\n      </p>\n      <div className=\"flex flex-wrap items-center gap-2\">\n        <AsyncButton onClick={() => wait(2000)} startIcon={<SendIcon />}>\n          Send Message\n        </AsyncButton>\n        <AsyncButton\n          endIcon={<ArrowRightIcon />}\n          onClick={() => wait(2000)}\n          variant=\"outline\"\n        >\n          Continue\n        </AsyncButton>\n        <AsyncButton\n          endIcon={<ArrowRightIcon />}\n          onClick={() => wait(2000)}\n          startIcon={<DownloadIcon />}\n          variant=\"secondary\"\n        >\n          Download &amp; Next\n        </AsyncButton>\n      </div>\n    </div>\n\n    <div className=\"flex flex-col gap-2\">\n      <p className=\"text-muted-foreground text-sm\">\n        Icon buttons with <code>size=\"icon\"</code>.\n      </p>\n      <div className=\"flex flex-wrap items-center gap-2\">\n        <AsyncButton onClick={() => wait(2000)} size=\"icon\">\n          <SendIcon />\n        </AsyncButton>\n        <AsyncButton onClick={() => wait(2000)} size=\"icon\" variant=\"outline\">\n          <RefreshCwIcon />\n        </AsyncButton>\n        <AsyncButton\n          onClick={() => wait(2000)}\n          size=\"icon\"\n          variant=\"destructive\"\n        >\n          <Trash2Icon />\n        </AsyncButton>\n      </div>\n    </div>\n\n    <div className=\"flex flex-col gap-2\">\n      <p className=\"text-muted-foreground text-sm\">\n        Anti-flash: a 50ms task still shows the spinner for at least 200ms (the\n        default <code>minDuration</code>), so the indicator never just flickers\n        past.\n      </p>\n      <div className=\"flex flex-wrap items-center gap-2\">\n        <AsyncButton onClick={() => wait(50)}>Fast Save (50ms)</AsyncButton>\n      </div>\n    </div>\n\n    <div className=\"flex flex-col gap-2\">\n      <p className=\"text-muted-foreground text-sm\">\n        Errors are caught and logged — the button recovers gracefully.\n      </p>\n      <div className=\"flex flex-wrap items-center gap-2\">\n        <AsyncButton\n          onClick={() =>\n            wait(1500).then(() => {\n              throw new Error(\"Request failed\");\n            })\n          }\n          variant=\"destructive\"\n        >\n          Simulate Failure\n        </AsyncButton>\n      </div>\n    </div>\n  </div>\n);\n\nexport default Demo;\n"
   },
 
   "calendar-demo": {
     component: React.lazy(() => import("./calendar-demo")),
-    codeString: `"use client";
-
-import { useState } from "react";
-import { Calendar } from "@/registry/ui/calendar";
-
-const Demo = () => {
-  const [single, setSingle] = useState<Date | undefined>();
-  const [monthsDate, setMonthsDate] = useState<Date | undefined>();
-  const [yearsDate, setYearsDate] = useState<Date | undefined>();
-  const [multiple, setMultiple] = useState<Date[] | undefined>();
-
-  return (
-    <div className="flex flex-col gap-6">
-      <div className="flex flex-col gap-2">
-        <span className="text-muted-foreground text-sm">
-          Days view — click month or year in the caption
-        </span>
-        <Calendar mode="single" onSelect={setSingle} selected={single} />
-      </div>
-
-      <div className="flex flex-col gap-2">
-        <span className="text-muted-foreground text-sm">
-          Months view (defaultView=&quot;months&quot;)
-        </span>
-        <Calendar
-          defaultView="months"
-          mode="single"
-          onSelect={setMonthsDate}
-          selected={monthsDate}
-        />
-      </div>
-
-      <div className="flex flex-col gap-2">
-        <span className="text-muted-foreground text-sm">
-          Years view (defaultView=&quot;years&quot;)
-        </span>
-        <Calendar
-          defaultView="years"
-          mode="single"
-          onSelect={setYearsDate}
-          selected={yearsDate}
-        />
-      </div>
-
-      <div className="flex flex-col gap-2">
-        <span className="text-muted-foreground text-sm">
-          Multiple — click multiple days to toggle selection
-        </span>
-        <Calendar mode="multiple" onSelect={setMultiple} selected={multiple} />
-      </div>
-    </div>
-  );
-};
-
-export default Demo;
-`
+    codeString: "\"use client\";\n\nimport { useState } from \"react\";\nimport { Calendar } from \"@/registry/ui/calendar\";\n\nconst Demo = () => {\n  const [single, setSingle] = useState<Date | undefined>();\n  const [monthsDate, setMonthsDate] = useState<Date | undefined>();\n  const [yearsDate, setYearsDate] = useState<Date | undefined>();\n  const [multiple, setMultiple] = useState<Date[] | undefined>();\n\n  return (\n    <div className=\"flex flex-col gap-6\">\n      <div className=\"flex flex-col gap-2\">\n        <span className=\"text-muted-foreground text-sm\">\n          Days view — click month or year in the caption\n        </span>\n        <Calendar mode=\"single\" onSelect={setSingle} selected={single} />\n      </div>\n\n      <div className=\"flex flex-col gap-2\">\n        <span className=\"text-muted-foreground text-sm\">\n          Months view (defaultView=&quot;months&quot;)\n        </span>\n        <Calendar\n          defaultView=\"months\"\n          mode=\"single\"\n          onSelect={setMonthsDate}\n          selected={monthsDate}\n        />\n      </div>\n\n      <div className=\"flex flex-col gap-2\">\n        <span className=\"text-muted-foreground text-sm\">\n          Years view (defaultView=&quot;years&quot;)\n        </span>\n        <Calendar\n          defaultView=\"years\"\n          mode=\"single\"\n          onSelect={setYearsDate}\n          selected={yearsDate}\n        />\n      </div>\n\n      <div className=\"flex flex-col gap-2\">\n        <span className=\"text-muted-foreground text-sm\">\n          Multiple — click multiple days to toggle selection\n        </span>\n        <Calendar mode=\"multiple\" onSelect={setMultiple} selected={multiple} />\n      </div>\n    </div>\n  );\n};\n\nexport default Demo;\n"
   },
 
   "card-demo": {
     component: React.lazy(() => import("./card-demo")),
-    codeString: `import { AsyncButton } from "@/registry/ui/async-button";
-import { Card } from "@/registry/ui/card";
-
-const Demo = () => (
-  <div className="space-y-4">
-    <Card
-      action={<AsyncButton variant="outline">More</AsyncButton>}
-      className="w-128"
-      description="some descriptions"
-      footer={<AsyncButton>Button</AsyncButton>}
-      footerClassName="flex justify-end"
-      title="Default Card"
-    >
-      <div>
-        <div>No dividers</div>
-        <div>No dividers</div>
-        <div>No dividers</div>
-      </div>
-    </Card>
-
-    <Card
-      className="w-72"
-      contentClassName="bg-white"
-      description="using className"
-      descriptionClassName="text-gray-500"
-      dividers
-      footer="Custom Card Footer"
-      size="sm"
-      title="Small Card"
-    >
-      <ul>
-        <li>Size: sm</li>
-        <li>dividers: true</li>
-      </ul>
-    </Card>
-  </div>
-);
-
-export default Demo;
-`
+    codeString: "import { AsyncButton } from \"@/registry/ui/async-button\";\nimport { Card } from \"@/registry/ui/card\";\n\nconst Demo = () => (\n  <div className=\"space-y-4\">\n    <Card\n      action={<AsyncButton variant=\"outline\">More</AsyncButton>}\n      className=\"w-128\"\n      description=\"some descriptions\"\n      footer={<AsyncButton>Button</AsyncButton>}\n      footerClassName=\"flex justify-end\"\n      title=\"Default Card\"\n    >\n      <div>\n        <div>No dividers</div>\n        <div>No dividers</div>\n        <div>No dividers</div>\n      </div>\n    </Card>\n\n    <Card\n      className=\"w-72\"\n      contentClassName=\"bg-white\"\n      description=\"using className\"\n      descriptionClassName=\"text-gray-500\"\n      dividers\n      footer=\"Custom Card Footer\"\n      size=\"sm\"\n      title=\"Small Card\"\n    >\n      <ul>\n        <li>Size: sm</li>\n        <li>dividers: true</li>\n      </ul>\n    </Card>\n  </div>\n);\n\nexport default Demo;\n"
   },
 
   "date-picker-demo": {
     component: React.lazy(() => import("./date-picker-demo")),
-    codeString: `"use client";
-
-import { useState } from "react";
-import type { DateRange } from "react-day-picker";
-import { DatePicker } from "@/registry/ui/date-picker";
-
-const Demo = () => {
-  const [single, setSingle] = useState<Date | undefined>();
-  const [multiple, setMultiple] = useState<Date[] | undefined>();
-  const [range, setRange] = useState<DateRange | undefined>();
-  const [typed, setTyped] = useState<Date | undefined>();
-
-  return (
-    <div className="flex flex-col gap-6">
-      <div className="flex flex-col gap-2">
-        <span className="text-muted-foreground text-sm">
-          Single (default trigger, format=&quot;PPP&quot;)
-        </span>
-        <DatePicker onChange={setSingle} value={single} />
-      </div>
-
-      <div className="flex flex-col gap-2">
-        <span className="text-muted-foreground text-sm">
-          Multiple (single panel, format=&quot;LLL dd, y&quot;)
-        </span>
-        <DatePicker
-          format="LLL dd, y"
-          mode="multiple"
-          onChange={setMultiple}
-          value={multiple}
-        />
-      </div>
-
-      <div className="flex flex-col gap-2">
-        <span className="text-muted-foreground text-sm">
-          Range (single panel, format=&quot;LLL dd, y&quot;)
-        </span>
-        <DatePicker
-          format="LLL dd, y"
-          mode="range"
-          onChange={setRange}
-          value={range}
-        />
-      </div>
-
-      <div className="flex flex-col gap-2">
-        <span className="text-muted-foreground text-sm">
-          With input — type a date and press Enter
-        </span>
-        <DatePicker onChange={setTyped} value={typed} withInput />
-      </div>
-    </div>
-  );
-};
-
-export default Demo;
-`
+    codeString: "\"use client\";\n\nimport { useState } from \"react\";\nimport type { DateRange } from \"react-day-picker\";\nimport { DatePicker } from \"@/registry/ui/date-picker\";\n\nconst Demo = () => {\n  const [single, setSingle] = useState<Date | undefined>();\n  const [multiple, setMultiple] = useState<Date[] | undefined>();\n  const [range, setRange] = useState<DateRange | undefined>();\n  const [typed, setTyped] = useState<Date | undefined>();\n\n  return (\n    <div className=\"flex flex-col gap-6\">\n      <div className=\"flex flex-col gap-2\">\n        <span className=\"text-muted-foreground text-sm\">\n          Single (default trigger, format=&quot;PPP&quot;)\n        </span>\n        <DatePicker onChange={setSingle} value={single} />\n      </div>\n\n      <div className=\"flex flex-col gap-2\">\n        <span className=\"text-muted-foreground text-sm\">\n          Multiple (single panel, format=&quot;LLL dd, y&quot;)\n        </span>\n        <DatePicker\n          format=\"LLL dd, y\"\n          mode=\"multiple\"\n          onChange={setMultiple}\n          value={multiple}\n        />\n      </div>\n\n      <div className=\"flex flex-col gap-2\">\n        <span className=\"text-muted-foreground text-sm\">\n          Range (single panel, format=&quot;LLL dd, y&quot;)\n        </span>\n        <DatePicker\n          format=\"LLL dd, y\"\n          mode=\"range\"\n          onChange={setRange}\n          value={range}\n        />\n      </div>\n\n      <div className=\"flex flex-col gap-2\">\n        <span className=\"text-muted-foreground text-sm\">\n          With input — type a date and press Enter\n        </span>\n        <DatePicker onChange={setTyped} value={typed} withInput />\n      </div>\n    </div>\n  );\n};\n\nexport default Demo;\n"
   },
 
   "modal-alert-demo": {
     component: React.lazy(() => import("./modal-alert-demo")),
-    codeString: `import { AsyncButton } from "@/registry/ui/async-button";
-import { AlertModal } from "@/registry/ui/modal";
-
-const Demo = () => (
-  <div>
-    <AlertModal
-      description="Modal Content"
-      title="Alert Title"
-      trigger={<AsyncButton>Alert Modal</AsyncButton>}
-    />
-  </div>
-);
-
-export default Demo;
-`
+    codeString: "import { AsyncButton } from \"@/registry/ui/async-button\";\nimport { AlertModal } from \"@/registry/ui/modal\";\n\nconst Demo = () => (\n  <div>\n    <AlertModal\n      description=\"Modal Content\"\n      title=\"Alert Title\"\n      trigger={<AsyncButton>Alert Modal</AsyncButton>}\n    />\n  </div>\n);\n\nexport default Demo;\n"
   },
 
   "modal-alert-helper-demo": {
     component: React.lazy(() => import("./modal-alert-helper-demo")),
-    codeString: `import { AsyncButton } from "@/registry/ui/async-button";
-import { AlertModal } from "@/registry/ui/modal";
-
-const Demo = () => (
-  <div className="space-x-2">
-    <AsyncButton
-      onClick={() => {
-        AlertModal.alert({
-          title: "Tips",
-          description: "Alert Content",
-        });
-      }}
-    >
-      Click Alert
-    </AsyncButton>
-    <AsyncButton
-      onClick={() => {
-        AlertModal.confirm({
-          title: "Tips",
-          description:
-            "If onConfirm or onCancel is asynchronous events, the button will automatically display loading",
-          onCancel: () => {
-            console.log("cancel");
-          },
-          onConfirm: () =>
-            new Promise((resolve) => {
-              setTimeout(() => {
-                console.log("confirm");
-                resolve();
-              }, 1000);
-            }),
-        });
-      }}
-    >
-      Click Confirm
-    </AsyncButton>
-    <AsyncButton
-      onClick={async () => {
-        await AlertModal.alert({
-          title: "Tips1",
-          description: "Alert Content-1",
-        });
-        await AlertModal.alert({
-          title: "Tips2",
-          description: "Alert Content-2",
-        });
-      }}
-    >
-      Alert Step by Step
-    </AsyncButton>
-    <AsyncButton
-      onClick={async () => {
-        await AlertModal.alert({
-          title: "Tips1",
-          description: (
-            <div>
-              <div>Alert Content-1</div>
-              <div>Alert Content-1</div>
-              <div>Alert Content-1</div>
-              <div>Alert Content-1</div>
-              <div>Alert Content-1</div>
-            </div>
-          ),
-          onConfirm: async () => {
-            await AlertModal.alert({
-              title: "Tips1-1",
-              description: "Alert Content-1-1",
-            });
-          },
-        });
-      }}
-    >
-      Alert Step In Step
-    </AsyncButton>
-  </div>
-);
-
-export default Demo;
-`
+    codeString: "import { AsyncButton } from \"@/registry/ui/async-button\";\nimport { AlertModal } from \"@/registry/ui/modal\";\n\nconst Demo = () => (\n  <div className=\"space-x-2\">\n    <AsyncButton\n      onClick={() => {\n        AlertModal.alert({\n          title: \"Tips\",\n          description: \"Alert Content\",\n        });\n      }}\n    >\n      Click Alert\n    </AsyncButton>\n    <AsyncButton\n      onClick={() => {\n        AlertModal.confirm({\n          title: \"Tips\",\n          description:\n            \"If onConfirm or onCancel is asynchronous events, the button will automatically display loading\",\n          onCancel: () => {\n            console.log(\"cancel\");\n          },\n          onConfirm: () =>\n            new Promise((resolve) => {\n              setTimeout(() => {\n                console.log(\"confirm\");\n                resolve();\n              }, 1000);\n            }),\n        });\n      }}\n    >\n      Click Confirm\n    </AsyncButton>\n    <AsyncButton\n      onClick={async () => {\n        await AlertModal.alert({\n          title: \"Tips1\",\n          description: \"Alert Content-1\",\n        });\n        await AlertModal.alert({\n          title: \"Tips2\",\n          description: \"Alert Content-2\",\n        });\n      }}\n    >\n      Alert Step by Step\n    </AsyncButton>\n    <AsyncButton\n      onClick={async () => {\n        await AlertModal.alert({\n          title: \"Tips1\",\n          description: (\n            <div>\n              <div>Alert Content-1</div>\n              <div>Alert Content-1</div>\n              <div>Alert Content-1</div>\n              <div>Alert Content-1</div>\n              <div>Alert Content-1</div>\n            </div>\n          ),\n          onConfirm: async () => {\n            await AlertModal.alert({\n              title: \"Tips1-1\",\n              description: \"Alert Content-1-1\",\n            });\n          },\n        });\n      }}\n    >\n      Alert Step In Step\n    </AsyncButton>\n  </div>\n);\n\nexport default Demo;\n"
   },
 
   "modal-demo": {
     component: React.lazy(() => import("./modal-demo")),
-    codeString: `import { useState } from "react";
-import { AsyncButton } from "@/registry/ui/async-button";
-import { Modal } from "@/registry/ui/modal";
-
-const Demo = () => {
-  const [showModal, setShowModal] = useState(false);
-
-  return (
-    <div>
-      <Modal
-        footer={
-          <div className="space-x-2">
-            <AsyncButton
-              onClick={() => {
-                setShowModal(false);
-              }}
-              variant="ghost"
-            >
-              Cancel
-            </AsyncButton>
-            <AsyncButton>Save</AsyncButton>
-          </div>
-        }
-        onOpenChange={setShowModal}
-        open={showModal}
-        title="Modal Title"
-        trigger={<AsyncButton>Click Show Modal</AsyncButton>}
-      >
-        <div>Modal Content</div>
-        <div>Modal Content</div>
-        <div>Modal Content</div>
-        <div>Modal Content</div>
-      </Modal>
-    </div>
-  );
-};
-
-export default Demo;
-`
+    codeString: "import { useState } from \"react\";\nimport { AsyncButton } from \"@/registry/ui/async-button\";\nimport { Modal } from \"@/registry/ui/modal\";\n\nconst Demo = () => {\n  const [showModal, setShowModal] = useState(false);\n\n  return (\n    <div>\n      <Modal\n        footer={\n          <div className=\"space-x-2\">\n            <AsyncButton\n              onClick={() => {\n                setShowModal(false);\n              }}\n              variant=\"ghost\"\n            >\n              Cancel\n            </AsyncButton>\n            <AsyncButton>Save</AsyncButton>\n          </div>\n        }\n        onOpenChange={setShowModal}\n        open={showModal}\n        title=\"Modal Title\"\n        trigger={<AsyncButton>Click Show Modal</AsyncButton>}\n      >\n        <div>Modal Content</div>\n        <div>Modal Content</div>\n        <div>Modal Content</div>\n        <div>Modal Content</div>\n      </Modal>\n    </div>\n  );\n};\n\nexport default Demo;\n"
   },
 
   "modal-helper-holder-demo": {
     component: React.lazy(() => import("./modal-helper-holder-demo")),
-    codeString: `import { useRef, useState } from "react";
-import { AsyncButton } from "@/registry/ui/async-button";
-import { Modal } from "@/registry/ui/modal";
-
-const CommandModalModal = Modal.create(({ count }: { count: number }) => {
-  const modal = Modal.useModal();
-
-  return (
-    <Modal
-      {...modal.modalProps}
-      footer={
-        <div className="space-x-2">
-          <AsyncButton
-            onClick={() => {
-              modal.hide();
-            }}
-            variant="ghost"
-          >
-            Cancel
-          </AsyncButton>
-          <AsyncButton>Save</AsyncButton>
-        </div>
-      }
-      title="Modal Will Update by props"
-    >
-      <p>AnyModalContent: {count}</p>
-      <p>Count will be updated in 1 second</p>
-    </Modal>
-  );
-});
-
-const Demo = () => {
-  const [action, ModalHolder] = Modal.useModalHolder(CommandModalModal);
-
-  const [count, setCount] = useState(0);
-  const countRef = useRef<NodeJS.Timeout | null>(null);
-
-  const handleClick = () => {
-    countRef.current && clearInterval(countRef.current);
-    action.show();
-
-    countRef.current = setInterval(() => {
-      setCount((c) => c + 1);
-    }, 1000);
-  };
-
-  return (
-    <Modal.Provider>
-      <AsyncButton onClick={handleClick}>Click Show Modal</AsyncButton>
-      <p>Current Count: {count}</p>
-      <ModalHolder count={count} />
-    </Modal.Provider>
-  );
-};
-
-export default Demo;
-`
+    codeString: "import { useRef, useState } from \"react\";\nimport { AsyncButton } from \"@/registry/ui/async-button\";\nimport { Modal } from \"@/registry/ui/modal\";\n\nconst CommandModalModal = Modal.create(({ count }: { count: number }) => {\n  const modal = Modal.useModal();\n\n  return (\n    <Modal\n      {...modal.modalProps}\n      footer={\n        <div className=\"space-x-2\">\n          <AsyncButton\n            onClick={() => {\n              modal.hide();\n            }}\n            variant=\"ghost\"\n          >\n            Cancel\n          </AsyncButton>\n          <AsyncButton>Save</AsyncButton>\n        </div>\n      }\n      title=\"Modal Will Update by props\"\n    >\n      <p>AnyModalContent: {count}</p>\n      <p>Count will be updated in 1 second</p>\n    </Modal>\n  );\n});\n\nconst Demo = () => {\n  const [action, ModalHolder] = Modal.useModalHolder(CommandModalModal);\n\n  const [count, setCount] = useState(0);\n  const countRef = useRef<NodeJS.Timeout | null>(null);\n\n  const handleClick = () => {\n    countRef.current && clearInterval(countRef.current);\n    action.show();\n\n    countRef.current = setInterval(() => {\n      setCount((c) => c + 1);\n    }, 1000);\n  };\n\n  return (\n    <Modal.Provider>\n      <AsyncButton onClick={handleClick}>Click Show Modal</AsyncButton>\n      <p>Current Count: {count}</p>\n      <ModalHolder count={count} />\n    </Modal.Provider>\n  );\n};\n\nexport default Demo;\n"
   },
 
   "select-async-demo": {
     component: React.lazy(() => import("./select-async-demo")),
-    codeString: `"use client";
-
-import { Select, type SelectItem } from "@/registry/ui/select";
-
-const COUNTRIES: SelectItem[] = [
-  { label: "Argentina", value: "ar" },
-  { label: "Australia", value: "au" },
-  { label: "Brazil", value: "br" },
-  { label: "Canada", value: "ca" },
-  { label: "China", value: "cn" },
-  { label: "France", value: "fr" },
-  { label: "Germany", value: "de" },
-  { label: "India", value: "in" },
-  { label: "Italy", value: "it" },
-  { label: "Japan", value: "jp" },
-  { label: "Mexico", value: "mx" },
-  { label: "Netherlands", value: "nl" },
-  { label: "Spain", value: "es" },
-  { label: "United Kingdom", value: "uk" },
-  { label: "United States", value: "us" },
-];
-
-const loadCountries = async (
-  _query: string,
-  signal: AbortSignal
-): Promise<SelectItem[]> => {
-  await new Promise<void>((resolve, reject) => {
-    const t = setTimeout(resolve, 600);
-    signal.addEventListener("abort", () => {
-      clearTimeout(t);
-      reject(new DOMException("Aborted", "AbortError"));
-    });
-  });
-  return COUNTRIES;
-};
-
-const Demo = () => (
-  <div className="w-64">
-    <Select
-      clearable
-      loadItems={loadCountries}
-      loadOn="open"
-      placeholder="Search a country"
-      searchable
-    />
-  </div>
-);
-
-export default Demo;
-`
+    codeString: "\"use client\";\n\nimport { Select, type SelectItem } from \"@/registry/ui/select\";\n\nconst COUNTRIES: SelectItem[] = [\n  { label: \"Argentina\", value: \"ar\" },\n  { label: \"Australia\", value: \"au\" },\n  { label: \"Brazil\", value: \"br\" },\n  { label: \"Canada\", value: \"ca\" },\n  { label: \"China\", value: \"cn\" },\n  { label: \"France\", value: \"fr\" },\n  { label: \"Germany\", value: \"de\" },\n  { label: \"India\", value: \"in\" },\n  { label: \"Italy\", value: \"it\" },\n  { label: \"Japan\", value: \"jp\" },\n  { label: \"Mexico\", value: \"mx\" },\n  { label: \"Netherlands\", value: \"nl\" },\n  { label: \"Spain\", value: \"es\" },\n  { label: \"United Kingdom\", value: \"uk\" },\n  { label: \"United States\", value: \"us\" },\n];\n\nconst loadCountries = async (\n  _query: string,\n  signal: AbortSignal\n): Promise<SelectItem[]> => {\n  await new Promise<void>((resolve, reject) => {\n    const t = setTimeout(resolve, 600);\n    signal.addEventListener(\"abort\", () => {\n      clearTimeout(t);\n      reject(new DOMException(\"Aborted\", \"AbortError\"));\n    });\n  });\n  return COUNTRIES;\n};\n\nconst Demo = () => (\n  <div className=\"w-64\">\n    <Select\n      clearable\n      loadItems={loadCountries}\n      loadOn=\"open\"\n      placeholder=\"Search a country\"\n      searchable\n    />\n  </div>\n);\n\nexport default Demo;\n"
   },
 
   "select-demo": {
     component: React.lazy(() => import("./select-demo")),
-    codeString: `import { Select } from "@/registry/ui/select";
-
-const items = [
-  { label: "Apple", value: "apple" },
-  { label: "Banana", value: "banana" },
-  { label: "Cherry", value: "cherry" },
-  { label: "Durian", value: "durian" },
-  { label: "Elderberry", value: "elderberry" },
-];
-
-const Demo = () => (
-  <div className="w-64">
-    <Select items={items} placeholder="Pick a fruit" />
-  </div>
-);
-
-export default Demo;
-`
+    codeString: "import { Select } from \"@/registry/ui/select\";\n\nconst items = [\n  { label: \"Apple\", value: \"apple\" },\n  { label: \"Banana\", value: \"banana\" },\n  { label: \"Cherry\", value: \"cherry\" },\n  { label: \"Durian\", value: \"durian\" },\n  { label: \"Elderberry\", value: \"elderberry\" },\n];\n\nconst Demo = () => (\n  <div className=\"w-64\">\n    <Select items={items} placeholder=\"Pick a fruit\" />\n  </div>\n);\n\nexport default Demo;\n"
   },
 
   "select-multiple-demo": {
     component: React.lazy(() => import("./select-multiple-demo")),
-    codeString: `import { Select } from "@/registry/ui/select";
-
-const items = [
-  { label: "TypeScript", value: "typescript" },
-  { label: "JavaScript", value: "javascript" },
-  { label: "Python", value: "python" },
-  { label: "Rust", value: "rust" },
-  { label: "Go", value: "go" },
-  { label: "Java", value: "java" },
-  { label: "C++", value: "cpp" },
-  { label: "Ruby", value: "ruby" },
-];
-
-const Demo = () => (
-  <div className="w-80">
-    <Select items={items} multiple placeholder="Pick languages" />
-  </div>
-);
-
-export default Demo;
-`
+    codeString: "import { Select } from \"@/registry/ui/select\";\n\nconst items = [\n  { label: \"TypeScript\", value: \"typescript\" },\n  { label: \"JavaScript\", value: \"javascript\" },\n  { label: \"Python\", value: \"python\" },\n  { label: \"Rust\", value: \"rust\" },\n  { label: \"Go\", value: \"go\" },\n  { label: \"Java\", value: \"java\" },\n  { label: \"C++\", value: \"cpp\" },\n  { label: \"Ruby\", value: \"ruby\" },\n];\n\nconst Demo = () => (\n  <div className=\"w-80\">\n    <Select items={items} multiple placeholder=\"Pick languages\" />\n  </div>\n);\n\nexport default Demo;\n"
   },
 
   "select-searchable-demo": {
     component: React.lazy(() => import("./select-searchable-demo")),
-    codeString: `import { Select } from "@/registry/ui/select";
-
-const items = [
-  { label: "Afghanistan", value: "af" },
-  { label: "Albania", value: "al" },
-  { label: "Algeria", value: "dz" },
-  { label: "Argentina", value: "ar" },
-  { label: "Australia", value: "au" },
-  { label: "Austria", value: "at" },
-  { label: "Belgium", value: "be" },
-  { label: "Brazil", value: "br" },
-  { label: "Canada", value: "ca" },
-  { label: "Chile", value: "cl" },
-  { label: "China", value: "cn" },
-  { label: "Colombia", value: "co" },
-  { label: "Denmark", value: "dk" },
-  { label: "Egypt", value: "eg" },
-  { label: "Finland", value: "fi" },
-  { label: "France", value: "fr" },
-  { label: "Germany", value: "de" },
-  { label: "Greece", value: "gr" },
-  { label: "India", value: "in" },
-  { label: "Indonesia", value: "id" },
-  { label: "Italy", value: "it" },
-  { label: "Japan", value: "jp" },
-  { label: "Mexico", value: "mx" },
-  { label: "Netherlands", value: "nl" },
-  { label: "Norway", value: "no" },
-  { label: "Poland", value: "pl" },
-  { label: "Portugal", value: "pt" },
-  { label: "Russia", value: "ru" },
-  { label: "Spain", value: "es" },
-  { label: "Sweden", value: "se" },
-  { label: "Switzerland", value: "ch" },
-  { label: "United Kingdom", value: "gb" },
-  { label: "United States", value: "us" },
-];
-
-const Demo = () => (
-  <div className="w-64">
-    <Select clearable items={items} placeholder="Search a country" searchable />
-  </div>
-);
-
-export default Demo;
-`
+    codeString: "import { Select } from \"@/registry/ui/select\";\n\nconst items = [\n  { label: \"Afghanistan\", value: \"af\" },\n  { label: \"Albania\", value: \"al\" },\n  { label: \"Algeria\", value: \"dz\" },\n  { label: \"Argentina\", value: \"ar\" },\n  { label: \"Australia\", value: \"au\" },\n  { label: \"Austria\", value: \"at\" },\n  { label: \"Belgium\", value: \"be\" },\n  { label: \"Brazil\", value: \"br\" },\n  { label: \"Canada\", value: \"ca\" },\n  { label: \"Chile\", value: \"cl\" },\n  { label: \"China\", value: \"cn\" },\n  { label: \"Colombia\", value: \"co\" },\n  { label: \"Denmark\", value: \"dk\" },\n  { label: \"Egypt\", value: \"eg\" },\n  { label: \"Finland\", value: \"fi\" },\n  { label: \"France\", value: \"fr\" },\n  { label: \"Germany\", value: \"de\" },\n  { label: \"Greece\", value: \"gr\" },\n  { label: \"India\", value: \"in\" },\n  { label: \"Indonesia\", value: \"id\" },\n  { label: \"Italy\", value: \"it\" },\n  { label: \"Japan\", value: \"jp\" },\n  { label: \"Mexico\", value: \"mx\" },\n  { label: \"Netherlands\", value: \"nl\" },\n  { label: \"Norway\", value: \"no\" },\n  { label: \"Poland\", value: \"pl\" },\n  { label: \"Portugal\", value: \"pt\" },\n  { label: \"Russia\", value: \"ru\" },\n  { label: \"Spain\", value: \"es\" },\n  { label: \"Sweden\", value: \"se\" },\n  { label: \"Switzerland\", value: \"ch\" },\n  { label: \"United Kingdom\", value: \"gb\" },\n  { label: \"United States\", value: \"us\" },\n];\n\nconst Demo = () => (\n  <div className=\"w-64\">\n    <Select clearable items={items} placeholder=\"Search a country\" searchable />\n  </div>\n);\n\nexport default Demo;\n"
   },
 
   "select-server-search-demo": {
     component: React.lazy(() => import("./select-server-search-demo")),
-    codeString: `"use client";
+    codeString: "\"use client\";\n\nimport { useState } from \"react\";\nimport { Select, type SelectItem } from \"@/registry/ui/select\";\n\nconst USERS: SelectItem[] = [\n  { label: \"Ada Lovelace\", value: \"ada\" },\n  { label: \"Alan Turing\", value: \"alan\" },\n  { label: \"Barbara Liskov\", value: \"barbara\" },\n  { label: \"Donald Knuth\", value: \"donald\" },\n  { label: \"Edsger Dijkstra\", value: \"edsger\" },\n  { label: \"Grace Hopper\", value: \"grace\" },\n  { label: \"John von Neumann\", value: \"john\" },\n  { label: \"Linus Torvalds\", value: \"linus\" },\n  { label: \"Margaret Hamilton\", value: \"margaret\" },\n  { label: \"Richard Stallman\", value: \"richard\" },\n  { label: \"Tim Berners-Lee\", value: \"tim\" },\n  { label: \"Yukihiro Matsumoto\", value: \"yukihiro\" },\n];\n\nconst searchUsers = async (\n  query: string,\n  signal: AbortSignal\n): Promise<SelectItem[]> => {\n  await new Promise<void>((resolve, reject) => {\n    const t = setTimeout(resolve, 450);\n    signal.addEventListener(\"abort\", () => {\n      clearTimeout(t);\n      reject(new DOMException(\"Aborted\", \"AbortError\"));\n    });\n  });\n  const q = query.trim().toLowerCase();\n  if (!q) {\n    return USERS.slice(0, 6);\n  }\n  return USERS.filter((u) => String(u.label).toLowerCase().includes(q)).slice(\n    0,\n    8\n  );\n};\n\nconst Demo = () => {\n  const [value, setValue] = useState<string[]>([]);\n  return (\n    <div className=\"flex w-72 flex-col gap-2\">\n      <Select\n        debounceMs={250}\n        loadItems={searchUsers}\n        multiple\n        onValueChange={(next) => setValue((next as string[]) ?? [])}\n        placeholder=\"Search reviewers\"\n        serverSideFilter\n        value={value}\n      />\n      <p className=\"text-muted-foreground text-xs\">\n        Selected:{\" \"}\n        <code className=\"text-foreground\">\n          {value.length === 0 ? \"—\" : value.join(\", \")}\n        </code>\n      </p>\n    </div>\n  );\n};\n\nexport default Demo;\n"
+  },
 
-import { useState } from "react";
-import { Select, type SelectItem } from "@/registry/ui/select";
+  "table-demo": {
+    component: React.lazy(() => import("./table-demo")),
+    codeString: "import { defineColumns, Table } from \"@/registry/ui/table\";\n\ninterface User {\n  email: string;\n  id: string;\n  name: string;\n  role: string;\n}\n\nconst data: User[] = [\n  { email: \"ada@example.com\", id: \"1\", name: \"Ada Lovelace\", role: \"Owner\" },\n  {\n    email: \"linus@example.com\",\n    id: \"2\",\n    name: \"Linus Torvalds\",\n    role: \"Admin\",\n  },\n  { email: \"grace@example.com\", id: \"3\", name: \"Grace Hopper\", role: \"Member\" },\n];\n\nconst columns = defineColumns<User>()([\n  { dataIndex: \"name\", key: \"name\", title: \"Name\" },\n  { dataIndex: \"email\", key: \"email\", title: \"Email\" },\n  { align: \"right\", dataIndex: \"role\", key: \"role\", title: \"Role\" },\n]);\n\nconst Demo = () => (\n  <div className=\"rounded-md border\">\n    <Table\n      aria-label=\"Team members\"\n      columns={columns}\n      dataSource={data}\n      rowKey=\"id\"\n    />\n  </div>\n);\n\nexport default Demo;\n"
+  },
 
-const USERS: SelectItem[] = [
-  { label: "Ada Lovelace", value: "ada" },
-  { label: "Alan Turing", value: "alan" },
-  { label: "Barbara Liskov", value: "barbara" },
-  { label: "Donald Knuth", value: "donald" },
-  { label: "Edsger Dijkstra", value: "edsger" },
-  { label: "Grace Hopper", value: "grace" },
-  { label: "John von Neumann", value: "john" },
-  { label: "Linus Torvalds", value: "linus" },
-  { label: "Margaret Hamilton", value: "margaret" },
-  { label: "Richard Stallman", value: "richard" },
-  { label: "Tim Berners-Lee", value: "tim" },
-  { label: "Yukihiro Matsumoto", value: "yukihiro" },
-];
+  "table-loading-empty-demo": {
+    component: React.lazy(() => import("./table-loading-empty-demo")),
+    codeString: "import { useState } from \"react\";\nimport { Button } from \"@/components/ui/button\";\nimport { defineColumns, Table } from \"@/registry/ui/table\";\n\ninterface Row {\n  id: string;\n  owner: string;\n  task: string;\n}\n\nconst sample: Row[] = [\n  { id: \"t1\", owner: \"Ada\", task: \"Design table API\" },\n  { id: \"t2\", owner: \"Linus\", task: \"Ship docs\" },\n];\n\nconst columns = defineColumns<Row>()([\n  { dataIndex: \"task\", key: \"task\", title: \"Task\" },\n  { dataIndex: \"owner\", key: \"owner\", title: \"Owner\" },\n]);\n\ntype Mode = \"data\" | \"loading\" | \"empty\";\n\nconst Demo = () => {\n  const [mode, setMode] = useState<Mode>(\"data\");\n  const dataSource = mode === \"data\" ? sample : [];\n\n  return (\n    <div className=\"space-y-3\">\n      <div className=\"flex gap-2\">\n        <Button\n          onClick={() => setMode(\"data\")}\n          size=\"sm\"\n          variant={mode === \"data\" ? \"default\" : \"outline\"}\n        >\n          With data\n        </Button>\n        <Button\n          onClick={() => setMode(\"loading\")}\n          size=\"sm\"\n          variant={mode === \"loading\" ? \"default\" : \"outline\"}\n        >\n          Loading\n        </Button>\n        <Button\n          onClick={() => setMode(\"empty\")}\n          size=\"sm\"\n          variant={mode === \"empty\" ? \"default\" : \"outline\"}\n        >\n          Empty\n        </Button>\n      </div>\n      <div className=\"rounded-md border\">\n        <Table\n          caption=\"Sprint backlog\"\n          columns={columns}\n          dataSource={dataSource}\n          emptyMessage=\"Nothing to do — go outside.\"\n          loading={mode === \"loading\"}\n          loadingMessage=\"Fetching tasks…\"\n          rowKey=\"id\"\n        />\n      </div>\n    </div>\n  );\n};\n\nexport default Demo;\n"
+  },
 
-const searchUsers = async (
-  query: string,
-  signal: AbortSignal
-): Promise<SelectItem[]> => {
-  await new Promise<void>((resolve, reject) => {
-    const t = setTimeout(resolve, 450);
-    signal.addEventListener("abort", () => {
-      clearTimeout(t);
-      reject(new DOMException("Aborted", "AbortError"));
-    });
-  });
-  const q = query.trim().toLowerCase();
-  if (!q) {
-    return USERS.slice(0, 6);
-  }
-  return USERS.filter((u) => String(u.label).toLowerCase().includes(q)).slice(
-    0,
-    8
-  );
-};
+  "table-render-demo": {
+    component: React.lazy(() => import("./table-render-demo")),
+    codeString: "import { useState } from \"react\";\nimport { Button } from \"@/components/ui/button\";\nimport { defineColumns, Table } from \"@/registry/ui/table\";\n\ninterface Order {\n  amount: number;\n  createdAt: string;\n  customer: string;\n  id: string;\n  status: \"paid\" | \"pending\" | \"refunded\";\n}\n\nconst data: Order[] = [\n  {\n    amount: 1299,\n    createdAt: \"2026-05-12\",\n    customer: \"Acme Inc.\",\n    id: \"ord_001\",\n    status: \"paid\",\n  },\n  {\n    amount: 480,\n    createdAt: \"2026-05-14\",\n    customer: \"Globex\",\n    id: \"ord_002\",\n    status: \"pending\",\n  },\n  {\n    amount: 75,\n    createdAt: \"2026-05-15\",\n    customer: \"Initech\",\n    id: \"ord_003\",\n    status: \"refunded\",\n  },\n];\n\nconst formatter = new Intl.NumberFormat(\"en-US\", {\n  currency: \"USD\",\n  style: \"currency\",\n});\n\nconst statusClass: Record<Order[\"status\"], string> = {\n  paid: \"bg-green-100 text-green-800\",\n  pending: \"bg-amber-100 text-amber-800\",\n  refunded: \"bg-zinc-100 text-zinc-800\",\n};\n\nconst Demo = () => {\n  const [viewing, setViewing] = useState<string | null>(null);\n\n  const columns = defineColumns<Order>()([\n    { dataIndex: \"id\", key: \"id\", title: \"Order\" },\n    { dataIndex: \"customer\", key: \"customer\", title: \"Customer\" },\n    {\n      align: \"right\",\n      dataIndex: \"amount\",\n      key: \"amount\",\n      // `value` narrows to `number`.\n      render: (value) => formatter.format(value),\n      title: \"Amount\",\n    },\n    {\n      dataIndex: \"status\",\n      key: \"status\",\n      // `value` narrows to Order[\"status\"].\n      render: (value) => (\n        <span\n          className={`inline-flex rounded-full px-2 py-0.5 font-medium text-xs ${statusClass[value]}`}\n        >\n          {value}\n        </span>\n      ),\n      title: \"Status\",\n    },\n    { dataIndex: \"createdAt\", key: \"createdAt\", title: \"Date\" },\n    {\n      align: \"right\",\n      key: \"actions\",\n      // No dataIndex — `value` is `undefined`, pull from `record` instead.\n      render: (_value, record) => (\n        <Button\n          onClick={() => setViewing(record.id)}\n          size=\"sm\"\n          variant=\"outline\"\n        >\n          View\n        </Button>\n      ),\n      title: \"Actions\",\n    },\n  ]);\n\n  return (\n    <div className=\"space-y-3\">\n      <p className=\"text-muted-foreground text-sm\">\n        {viewing ? `Viewing ${viewing}` : \"Click a row's View button\"}\n      </p>\n      <div className=\"rounded-md border\">\n        <Table\n          aria-label=\"Recent orders\"\n          columns={columns}\n          dataSource={data}\n          rowKey=\"id\"\n        />\n      </div>\n    </div>\n  );\n};\n\nexport default Demo;\n"
+  },
 
-const Demo = () => {
-  const [value, setValue] = useState<string[]>([]);
-  return (
-    <div className="flex w-72 flex-col gap-2">
-      <Select
-        debounceMs={250}
-        loadItems={searchUsers}
-        multiple
-        onValueChange={(next) => setValue((next as string[]) ?? [])}
-        placeholder="Search reviewers"
-        serverSideFilter
-        value={value}
-      />
-      <p className="text-muted-foreground text-xs">
-        Selected:{" "}
-        <code className="text-foreground">
-          {value.length === 0 ? "—" : value.join(", ")}
-        </code>
-      </p>
-    </div>
-  );
-};
+  "table-row-classname-demo": {
+    component: React.lazy(() => import("./table-row-classname-demo")),
+    codeString: "import { defineColumns, Table } from \"@/registry/ui/table\";\n\ninterface Server {\n  cpu: number;\n  id: string;\n  name: string;\n  region: string;\n}\n\nconst data: Server[] = [\n  { cpu: 32, id: \"s1\", name: \"api-1\", region: \"us-east-1\" },\n  { cpu: 91, id: \"s2\", name: \"api-2\", region: \"us-east-1\" },\n  { cpu: 12, id: \"s3\", name: \"worker-1\", region: \"eu-west-1\" },\n  { cpu: 88, id: \"s4\", name: \"worker-2\", region: \"ap-south-1\" },\n];\n\n// Three-state status so the high-CPU signal travels through icon + text +\n// colour — color alone fails colour-blind users (WCAG 1.4.1).\nconst statusFor = (cpu: number) => {\n  if (cpu >= 80) {\n    return \"hot\" as const;\n  }\n  if (cpu >= 60) {\n    return \"warm\" as const;\n  }\n  return \"ok\" as const;\n};\n\nconst statusIcon: Record<ReturnType<typeof statusFor>, string> = {\n  hot: \"▲\",\n  ok: \"·\",\n  warm: \"•\",\n};\n\nconst columns = defineColumns<Server>()([\n  { dataIndex: \"name\", key: \"name\", title: \"Server\" },\n  { dataIndex: \"region\", key: \"region\", title: \"Region\" },\n  {\n    align: \"right\",\n    dataIndex: \"cpu\",\n    key: \"cpu\",\n    // `value` narrows to `number`.\n    render: (value) => {\n      const status = statusFor(value);\n      return (\n        <span className=\"inline-flex items-center gap-1.5\">\n          <span aria-hidden className=\"font-mono\">\n            {statusIcon[status]}\n          </span>\n          <span>{value}%</span>\n          <span className=\"sr-only\">({status})</span>\n        </span>\n      );\n    },\n    title: \"CPU\",\n  },\n]);\n\nconst Demo = () => (\n  <div className=\"rounded-md border\">\n    <Table\n      aria-label=\"Server CPU usage\"\n      columns={columns}\n      dataSource={data}\n      rowClassName={(record) =>\n        record.cpu >= 80 ? \"bg-destructive/10\" : undefined\n      }\n      rowKey=\"id\"\n    />\n  </div>\n);\n\nexport default Demo;\n"
+  },
 
-export default Demo;
-`
+  "table-row-click-demo": {
+    component: React.lazy(() => import("./table-row-click-demo")),
+    codeString: "import { useState } from \"react\";\nimport { defineColumns, Table } from \"@/registry/ui/table\";\n\ninterface Member {\n  email: string;\n  id: string;\n  name: string;\n  role: \"owner\" | \"admin\" | \"member\";\n}\n\nconst data: Member[] = [\n  { email: \"ada@example.com\", id: \"u1\", name: \"Ada Lovelace\", role: \"owner\" },\n  {\n    email: \"linus@example.com\",\n    id: \"u2\",\n    name: \"Linus Torvalds\",\n    role: \"admin\",\n  },\n  {\n    email: \"grace@example.com\",\n    id: \"u3\",\n    name: \"Grace Hopper\",\n    role: \"member\",\n  },\n  { email: \"alan@example.com\", id: \"u4\", name: \"Alan Turing\", role: \"member\" },\n];\n\nconst columns = defineColumns<Member>()([\n  { dataIndex: \"name\", key: \"name\", title: \"Name\" },\n  { dataIndex: \"email\", key: \"email\", title: \"Email\" },\n  { dataIndex: \"role\", key: \"role\", title: \"Role\" },\n]);\n\nconst Demo = () => {\n  const [viewing, setViewing] = useState<string | null>(null);\n  const [selected, setSelected] = useState<string[]>([]);\n\n  return (\n    <div className=\"space-y-3\">\n      <p className=\"text-muted-foreground text-sm\">\n        {viewing ? `Viewing ${viewing}` : \"Click a row, or Tab + Enter / Space\"}\n        {selected.length > 0 ? ` · selected: ${selected.join(\", \")}` : \"\"}\n      </p>\n      <div className=\"rounded-md border\">\n        <Table\n          aria-label=\"Team members\"\n          columns={columns}\n          dataSource={data}\n          getCheckboxProps={(record) => ({\n            \"aria-label\": `Select ${record.name}`,\n          })}\n          onRowClick={(record) => setViewing(record.id)}\n          onSelectedRowKeysChange={setSelected}\n          rowKey=\"id\"\n          selectable\n          selectedRowKeys={selected}\n        />\n      </div>\n    </div>\n  );\n};\n\nexport default Demo;\n"
+  },
+
+  "table-selection-demo": {
+    component: React.lazy(() => import("./table-selection-demo")),
+    codeString: "import { useState } from \"react\";\nimport { defineColumns, Table } from \"@/registry/ui/table\";\n\ninterface Member {\n  id: string;\n  name: string;\n  role: \"owner\" | \"admin\" | \"member\";\n}\n\nconst data: Member[] = [\n  { id: \"u1\", name: \"Ada Lovelace\", role: \"owner\" },\n  { id: \"u2\", name: \"Linus Torvalds\", role: \"admin\" },\n  { id: \"u3\", name: \"Grace Hopper\", role: \"member\" },\n  { id: \"u4\", name: \"Alan Turing\", role: \"member\" },\n];\n\nconst columns = defineColumns<Member>()([\n  { dataIndex: \"name\", key: \"name\", title: \"Name\" },\n  { dataIndex: \"role\", key: \"role\", title: \"Role\" },\n]);\n\nconst Demo = () => {\n  const [selected, setSelected] = useState<string[]>([]);\n\n  return (\n    <div className=\"space-y-3\">\n      <p className=\"text-muted-foreground text-sm\">\n        Selected: {selected.length === 0 ? \"none\" : selected.join(\", \")} (the\n        owner row is non-selectable)\n      </p>\n      <div className=\"rounded-md border\">\n        <Table\n          aria-label=\"Team members\"\n          columns={columns}\n          dataSource={data}\n          getCheckboxProps={(record) => ({\n            // Human-readable label so screen readers announce the row\n            // identity, not the opaque rowKey.\n            \"aria-label\": `Select ${record.name}`,\n            disabled: record.role === \"owner\",\n          })}\n          onSelectedRowKeysChange={setSelected}\n          rowKey=\"id\"\n          selectable\n          selectedRowKeys={selected}\n        />\n      </div>\n    </div>\n  );\n};\n\nexport default Demo;\n"
   },
 
   "tabs-demo": {
     component: React.lazy(() => import("./tabs-demo")),
-    codeString: `import { Tabs } from "@/registry/ui/tabs";
-
-const Demo = () => (
-  <Tabs
-    defaultValue="first"
-    items={[
-      {
-        label: "First",
-        value: "first",
-        content: (
-          <div className="rounded-2xl border bg-accent p-6">First Content</div>
-        ),
-      },
-      {
-        label: "Second",
-        value: "second",
-        content: (
-          <div className="rounded-2xl border bg-accent-foreground p-6 text-accent">
-            Second Content
-          </div>
-        ),
-      },
-    ]}
-  />
-);
-
-export default Demo;
-`
+    codeString: "import { Tabs } from \"@/registry/ui/tabs\";\n\nconst Demo = () => (\n  <Tabs\n    defaultValue=\"first\"\n    items={[\n      {\n        label: \"First\",\n        value: \"first\",\n        content: (\n          <div className=\"rounded-2xl border bg-accent p-6\">First Content</div>\n        ),\n      },\n      {\n        label: \"Second\",\n        value: \"second\",\n        content: (\n          <div className=\"rounded-2xl border bg-accent-foreground p-6 text-accent\">\n            Second Content\n          </div>\n        ),\n      },\n    ]}\n  />\n);\n\nexport default Demo;\n"
   },
 } as const

--- a/components/examples/table-demo.tsx
+++ b/components/examples/table-demo.tsx
@@ -1,0 +1,38 @@
+import { defineColumns, Table } from "@/registry/ui/table";
+
+interface User {
+  email: string;
+  id: string;
+  name: string;
+  role: string;
+}
+
+const data: User[] = [
+  { email: "ada@example.com", id: "1", name: "Ada Lovelace", role: "Owner" },
+  {
+    email: "linus@example.com",
+    id: "2",
+    name: "Linus Torvalds",
+    role: "Admin",
+  },
+  { email: "grace@example.com", id: "3", name: "Grace Hopper", role: "Member" },
+];
+
+const columns = defineColumns<User>()([
+  { dataIndex: "name", key: "name", title: "Name" },
+  { dataIndex: "email", key: "email", title: "Email" },
+  { align: "right", dataIndex: "role", key: "role", title: "Role" },
+]);
+
+const Demo = () => (
+  <div className="rounded-md border">
+    <Table
+      aria-label="Team members"
+      columns={columns}
+      dataSource={data}
+      rowKey="id"
+    />
+  </div>
+);
+
+export default Demo;

--- a/components/examples/table-loading-empty-demo.tsx
+++ b/components/examples/table-loading-empty-demo.tsx
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { defineColumns, Table } from "@/registry/ui/table";
+
+interface Row {
+  id: string;
+  owner: string;
+  task: string;
+}
+
+const sample: Row[] = [
+  { id: "t1", owner: "Ada", task: "Design table API" },
+  { id: "t2", owner: "Linus", task: "Ship docs" },
+];
+
+const columns = defineColumns<Row>()([
+  { dataIndex: "task", key: "task", title: "Task" },
+  { dataIndex: "owner", key: "owner", title: "Owner" },
+]);
+
+type Mode = "data" | "loading" | "empty";
+
+const Demo = () => {
+  const [mode, setMode] = useState<Mode>("data");
+  const dataSource = mode === "data" ? sample : [];
+
+  return (
+    <div className="space-y-3">
+      <div className="flex gap-2">
+        <Button
+          onClick={() => setMode("data")}
+          size="sm"
+          variant={mode === "data" ? "default" : "outline"}
+        >
+          With data
+        </Button>
+        <Button
+          onClick={() => setMode("loading")}
+          size="sm"
+          variant={mode === "loading" ? "default" : "outline"}
+        >
+          Loading
+        </Button>
+        <Button
+          onClick={() => setMode("empty")}
+          size="sm"
+          variant={mode === "empty" ? "default" : "outline"}
+        >
+          Empty
+        </Button>
+      </div>
+      <div className="rounded-md border">
+        <Table
+          caption="Sprint backlog"
+          columns={columns}
+          dataSource={dataSource}
+          emptyMessage="Nothing to do — go outside."
+          loading={mode === "loading"}
+          loadingMessage="Fetching tasks…"
+          rowKey="id"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default Demo;

--- a/components/examples/table-render-demo.tsx
+++ b/components/examples/table-render-demo.tsx
@@ -1,0 +1,110 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { defineColumns, Table } from "@/registry/ui/table";
+
+interface Order {
+  amount: number;
+  createdAt: string;
+  customer: string;
+  id: string;
+  status: "paid" | "pending" | "refunded";
+}
+
+const data: Order[] = [
+  {
+    amount: 1299,
+    createdAt: "2026-05-12",
+    customer: "Acme Inc.",
+    id: "ord_001",
+    status: "paid",
+  },
+  {
+    amount: 480,
+    createdAt: "2026-05-14",
+    customer: "Globex",
+    id: "ord_002",
+    status: "pending",
+  },
+  {
+    amount: 75,
+    createdAt: "2026-05-15",
+    customer: "Initech",
+    id: "ord_003",
+    status: "refunded",
+  },
+];
+
+const formatter = new Intl.NumberFormat("en-US", {
+  currency: "USD",
+  style: "currency",
+});
+
+const statusClass: Record<Order["status"], string> = {
+  paid: "bg-green-100 text-green-800",
+  pending: "bg-amber-100 text-amber-800",
+  refunded: "bg-zinc-100 text-zinc-800",
+};
+
+const Demo = () => {
+  const [viewing, setViewing] = useState<string | null>(null);
+
+  const columns = defineColumns<Order>()([
+    { dataIndex: "id", key: "id", title: "Order" },
+    { dataIndex: "customer", key: "customer", title: "Customer" },
+    {
+      align: "right",
+      dataIndex: "amount",
+      key: "amount",
+      // `value` narrows to `number`.
+      render: (value) => formatter.format(value),
+      title: "Amount",
+    },
+    {
+      dataIndex: "status",
+      key: "status",
+      // `value` narrows to Order["status"].
+      render: (value) => (
+        <span
+          className={`inline-flex rounded-full px-2 py-0.5 font-medium text-xs ${statusClass[value]}`}
+        >
+          {value}
+        </span>
+      ),
+      title: "Status",
+    },
+    { dataIndex: "createdAt", key: "createdAt", title: "Date" },
+    {
+      align: "right",
+      key: "actions",
+      // No dataIndex — `value` is `undefined`, pull from `record` instead.
+      render: (_value, record) => (
+        <Button
+          onClick={() => setViewing(record.id)}
+          size="sm"
+          variant="outline"
+        >
+          View
+        </Button>
+      ),
+      title: "Actions",
+    },
+  ]);
+
+  return (
+    <div className="space-y-3">
+      <p className="text-muted-foreground text-sm">
+        {viewing ? `Viewing ${viewing}` : "Click a row's View button"}
+      </p>
+      <div className="rounded-md border">
+        <Table
+          aria-label="Recent orders"
+          columns={columns}
+          dataSource={data}
+          rowKey="id"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default Demo;

--- a/components/examples/table-row-classname-demo.tsx
+++ b/components/examples/table-row-classname-demo.tsx
@@ -1,0 +1,73 @@
+import { defineColumns, Table } from "@/registry/ui/table";
+
+interface Server {
+  cpu: number;
+  id: string;
+  name: string;
+  region: string;
+}
+
+const data: Server[] = [
+  { cpu: 32, id: "s1", name: "api-1", region: "us-east-1" },
+  { cpu: 91, id: "s2", name: "api-2", region: "us-east-1" },
+  { cpu: 12, id: "s3", name: "worker-1", region: "eu-west-1" },
+  { cpu: 88, id: "s4", name: "worker-2", region: "ap-south-1" },
+];
+
+// Three-state status so the high-CPU signal travels through icon + text +
+// colour — color alone fails colour-blind users (WCAG 1.4.1).
+const statusFor = (cpu: number) => {
+  if (cpu >= 80) {
+    return "hot" as const;
+  }
+  if (cpu >= 60) {
+    return "warm" as const;
+  }
+  return "ok" as const;
+};
+
+const statusIcon: Record<ReturnType<typeof statusFor>, string> = {
+  hot: "▲",
+  ok: "·",
+  warm: "•",
+};
+
+const columns = defineColumns<Server>()([
+  { dataIndex: "name", key: "name", title: "Server" },
+  { dataIndex: "region", key: "region", title: "Region" },
+  {
+    align: "right",
+    dataIndex: "cpu",
+    key: "cpu",
+    // `value` narrows to `number`.
+    render: (value) => {
+      const status = statusFor(value);
+      return (
+        <span className="inline-flex items-center gap-1.5">
+          <span aria-hidden className="font-mono">
+            {statusIcon[status]}
+          </span>
+          <span>{value}%</span>
+          <span className="sr-only">({status})</span>
+        </span>
+      );
+    },
+    title: "CPU",
+  },
+]);
+
+const Demo = () => (
+  <div className="rounded-md border">
+    <Table
+      aria-label="Server CPU usage"
+      columns={columns}
+      dataSource={data}
+      rowClassName={(record) =>
+        record.cpu >= 80 ? "bg-destructive/10" : undefined
+      }
+      rowKey="id"
+    />
+  </div>
+);
+
+export default Demo;

--- a/components/examples/table-row-click-demo.tsx
+++ b/components/examples/table-row-click-demo.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import { defineColumns, Table } from "@/registry/ui/table";
+
+interface Member {
+  email: string;
+  id: string;
+  name: string;
+  role: "owner" | "admin" | "member";
+}
+
+const data: Member[] = [
+  { email: "ada@example.com", id: "u1", name: "Ada Lovelace", role: "owner" },
+  {
+    email: "linus@example.com",
+    id: "u2",
+    name: "Linus Torvalds",
+    role: "admin",
+  },
+  {
+    email: "grace@example.com",
+    id: "u3",
+    name: "Grace Hopper",
+    role: "member",
+  },
+  { email: "alan@example.com", id: "u4", name: "Alan Turing", role: "member" },
+];
+
+const columns = defineColumns<Member>()([
+  { dataIndex: "name", key: "name", title: "Name" },
+  { dataIndex: "email", key: "email", title: "Email" },
+  { dataIndex: "role", key: "role", title: "Role" },
+]);
+
+const Demo = () => {
+  const [viewing, setViewing] = useState<string | null>(null);
+  const [selected, setSelected] = useState<string[]>([]);
+
+  return (
+    <div className="space-y-3">
+      <p className="text-muted-foreground text-sm">
+        {viewing ? `Viewing ${viewing}` : "Click a row, or Tab + Enter / Space"}
+        {selected.length > 0 ? ` · selected: ${selected.join(", ")}` : ""}
+      </p>
+      <div className="rounded-md border">
+        <Table
+          aria-label="Team members"
+          columns={columns}
+          dataSource={data}
+          getCheckboxProps={(record) => ({
+            "aria-label": `Select ${record.name}`,
+          })}
+          onRowClick={(record) => setViewing(record.id)}
+          onSelectedRowKeysChange={setSelected}
+          rowKey="id"
+          selectable
+          selectedRowKeys={selected}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default Demo;

--- a/components/examples/table-selection-demo.tsx
+++ b/components/examples/table-selection-demo.tsx
@@ -1,0 +1,52 @@
+import { useState } from "react";
+import { defineColumns, Table } from "@/registry/ui/table";
+
+interface Member {
+  id: string;
+  name: string;
+  role: "owner" | "admin" | "member";
+}
+
+const data: Member[] = [
+  { id: "u1", name: "Ada Lovelace", role: "owner" },
+  { id: "u2", name: "Linus Torvalds", role: "admin" },
+  { id: "u3", name: "Grace Hopper", role: "member" },
+  { id: "u4", name: "Alan Turing", role: "member" },
+];
+
+const columns = defineColumns<Member>()([
+  { dataIndex: "name", key: "name", title: "Name" },
+  { dataIndex: "role", key: "role", title: "Role" },
+]);
+
+const Demo = () => {
+  const [selected, setSelected] = useState<string[]>([]);
+
+  return (
+    <div className="space-y-3">
+      <p className="text-muted-foreground text-sm">
+        Selected: {selected.length === 0 ? "none" : selected.join(", ")} (the
+        owner row is non-selectable)
+      </p>
+      <div className="rounded-md border">
+        <Table
+          aria-label="Team members"
+          columns={columns}
+          dataSource={data}
+          getCheckboxProps={(record) => ({
+            // Human-readable label so screen readers announce the row
+            // identity, not the opaque rowKey.
+            "aria-label": `Select ${record.name}`,
+            disabled: record.role === "owner",
+          })}
+          onSelectedRowKeysChange={setSelected}
+          rowKey="id"
+          selectable
+          selectedRowKeys={selected}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default Demo;

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox"
+
+import { cn } from "@/lib/utils"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Tick02Icon } from "@hugeicons/core-free-icons"
+
+function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
+      >
+        <HugeiconsIcon icon={Tick02Icon} strokeWidth={2} />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/content/docs/components/table.mdx
+++ b/content/docs/components/table.mdx
@@ -1,0 +1,257 @@
+---
+title: Table
+---
+
+A flat-props Table covering the 80% case — `columns` + `dataSource` + `rowKey`, with built-in loading, empty, caption, function-form `rowClassName`, and optional row selection. Built on the shadcn `table` and `checkbox` primitives.
+
+<ExamplePreview name="table-demo" />
+
+## Installation
+
+With the [`@easy-shadcn` namespace](/docs/installation) configured:
+
+```shell
+pnpm dlx shadcn@latest add @easy-shadcn/table
+```
+
+Or install via the full URL (zero configuration):
+
+```shell
+pnpm dlx shadcn@latest add https://easy-shadcn.vercel.app/r/table.json
+```
+
+The underlying shadcn `table` and `checkbox` primitives are installed automatically alongside `table`.
+
+After `shadcn add`, import from `@/components/easy/table`. The examples below import from `@/registry/ui/table` for repo-internal reasons — substitute the install path in your app.
+
+## Usage
+
+### Basic
+
+Define columns through the `defineColumns<T>()` builder (see below for why), then pass them to `Table`. `rowKey` is required — it derives a stable string key per row, either as a `keyof T` field name or a `(record, index) => string` function.
+
+```tsx
+import { defineColumns, Table } from "@/components/easy/table"
+
+interface User {
+  id: string
+  name: string
+  email: string
+}
+
+const columns = defineColumns<User>()([
+  { dataIndex: "name", key: "name", title: "Name" },
+  { dataIndex: "email", key: "email", title: "Email" },
+])
+
+<Table columns={columns} dataSource={users} rowKey="id" />
+```
+
+### Column types — why `defineColumns`
+
+`TableColumn<T>` is a discriminated union: when `dataIndex` is a literal `keyof T`, `render(value, record, index)` narrows `value` to `T[dataIndex]` (no casts). When `dataIndex` is omitted, `value` is `undefined` and you pull from `record`.
+
+The catch: TypeScript's contextual typing for inline array literals (`const cols: TableColumn<T>[] = [...]`) can drop narrowing under certain strict-mode combinations — `value` falls back to `any`, and invalid `dataIndex` literals stop erroring. The `defineColumns<T>()` builder fixes this by binding the generic before inference and using `const` parameters to keep each element's `dataIndex` literal alive:
+
+```tsx
+const cols = defineColumns<Order>()([
+  {
+    dataIndex: "amount",
+    key: "amount",
+    title: "Amount",
+    align: "right",
+    render: (value) => formatter.format(value), // value: number
+  },
+  {
+    dataIndex: "status",
+    key: "status",
+    title: "Status",
+    render: (value) => <Badge tone={value}>{value}</Badge>, // value: Order["status"]
+  },
+  {
+    key: "actions",
+    title: "Actions",
+    // No dataIndex → value is undefined.
+    render: (_value, record) => <Button onClick={() => view(record.id)}>View</Button>,
+  },
+])
+```
+
+You can still write `const cols: TableColumn<T>[] = [...]` directly if you don't need narrowing — `dataIndex` is still constrained to `keyof T`, `render` just has the union-of-shapes value type. Reach for `defineColumns` whenever you want IDE autocomplete to know what `value` is.
+
+`dataIndex` is intentionally limited to `keyof T` — nested paths like `"user.name"` are not supported. Reach inside with `render: (_, record) => record.user.name` instead.
+
+### Formatting cells with `column.render`
+
+`column.render` is the one render-style prop the project allows, because it lives at the *data* layer — formatting a value into a `ReactNode` — not the component layer. It receives `(value, record, index)` and lives inside each column definition above.
+
+<ExamplePreview name="table-render-demo" />
+
+### Loading, empty, and caption
+
+`loading={true}` replaces the body with `loadingMessage`. When `dataSource` is empty and `loading` is false, `emptyMessage` is shown. `caption` renders inside `<caption>`.
+
+<ExamplePreview name="table-loading-empty-demo" />
+
+### Row highlighting via `rowClassName`
+
+`rowClassName` accepts a `ClassValue` or a `(record, index) => ClassValue` function. Use the function form for conditional row styling without an extra wrapper.
+
+<ExamplePreview name="table-row-classname-demo" />
+
+```tsx
+<Table
+  columns={columns}
+  dataSource={servers}
+  rowKey="id"
+  rowClassName={(record) => record.cpu >= 80 ? "bg-destructive/10" : undefined}
+/>
+```
+
+### Row selection
+
+Set `selectable` to render a left-side checkbox column. The selection prop pair follows the same controlled / uncontrolled shape as other components in this library (`value` / `onValueChange` → `selectedRowKeys` / `onSelectedRowKeysChange`). The change callback receives both the new keys and the matching records in `dataSource` order, so you don't have to re-look-up rows. The header checkbox shows a distinct indeterminate (dash) icon while a non-empty proper subset is selected.
+
+Per-row checkbox configuration goes through `getCheckboxProps(record, index)` — pass `disabled: true` to gate a row out (it will also be skipped by "select all"). `getCheckboxProps` is the one `xxxProps` escape hatch in this library, kept for parity with Antd's Table API. `checked` and `onCheckedChange` are always owned by the Table.
+
+<ExamplePreview name="table-selection-demo" />
+
+```tsx
+const [selected, setSelected] = useState<string[]>([])
+
+<Table
+  columns={columns}
+  dataSource={members}
+  rowKey="id"
+  selectable
+  selectedRowKeys={selected}
+  onSelectedRowKeysChange={(keys, rows) => {
+    setSelected(keys)
+    console.log("selected rows:", rows)
+  }}
+  getCheckboxProps={(record) => ({
+    disabled: record.role === "owner",
+  })}
+/>
+```
+
+#### Selection across pages / filters
+
+Keys in `selectedRowKeys` that aren't present in the current `dataSource` are **preserved** — they survive pagination and filtering. `onSelectedRowKeysChange`'s second argument (`rows`) only contains the records that actually exist in `dataSource`, so consumers usually do:
+
+```tsx
+// `selected` lives in your parent state and accumulates across pages.
+<Table
+  columns={columns}
+  dataSource={pageData}
+  rowKey="id"
+  selectable
+  selectedRowKeys={selected}
+  onSelectedRowKeysChange={setSelected}
+/>
+```
+
+For a header counter that reflects *only the visible* selection, derive it from your own visible set rather than `selected.length`:
+
+```tsx
+const visibleSelected = selected.filter((k) => visibleIds.has(k));
+```
+
+### Row click
+
+Pass `onRowClick(record, index)` to make rows respond to interaction. The row keeps its native `role="row"` semantics (W3C ARIA APG grid pattern) but becomes focusable (`tabIndex=0`) and reacts to mouse click, Enter, and Space. Clicks that originate inside the selection cell do **not** bubble to `onRowClick`, so checkboxes stay independent.
+
+Other interactive elements inside cells (Button, Link, etc.) **do** bubble — call `event.stopPropagation()` from their own handlers if you don't want a click on them to also fire `onRowClick`.
+
+<ExamplePreview name="table-row-click-demo" />
+
+Try it: click a row body to set "viewing", then click a checkbox — the row click does not fire. Tab to a row and press Enter or Space to activate it.
+
+```tsx
+<Table
+  aria-label="Members"
+  columns={columns}
+  dataSource={members}
+  rowKey="id"
+  onRowClick={(record) => router.push(`/members/${record.id}`)}
+/>
+```
+
+## Accessibility
+
+The Table ships with the WCAG defaults you'd expect, plus dev-only warnings when they're missing:
+
+- **Accessible name (WCAG 1.3.1)** — pass `caption`, `aria-label`, or `aria-labelledby`. Without one, dev builds log a warning.
+- **`aria-busy`** is set on the `<table>` whenever `loading` is `true`.
+- **Loading / empty cells** carry `role="status"` + `aria-live="polite"` so SR users hear the state change instead of waiting in silence.
+- **Selection column** renders a visually-hidden `<span>` carrying `selectionColumnLabel` (default `"Selection"`) so the column has a real name for AT, even though the `<th>` shows only a checkbox.
+- **Selection checkboxes** default to `aria-label="Select row {key}"`. The row key is usually opaque — pass a human label through `getCheckboxProps`:
+
+  ```tsx
+  getCheckboxProps={(record) => ({ "aria-label": `Select ${record.name}` })}
+  ```
+
+- **`onRowClick`** preserves the native `<tr role="row">` semantics — we do NOT override to `role="button"` (that would strip the table structure). Rows get `tabIndex={0}` and respond to Enter / Space. Focus outline is inset (`outline-offset: -2px`) so a surrounding `border` won't clip it.
+- **Color is never the only signal** in row highlighting — pair `rowClassName` with an icon or text cue (see the row-className example).
+
+## API
+
+### `TableProps<T>`
+
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `columns` | `TableColumn<T>[]` | — | Column definitions. Use `defineColumns<T>()` for narrowed `render(value, …)` types. |
+| `dataSource` | `T[]` | — | Data rows. |
+| `rowKey` | `keyof T \| (record, index) => string` | — | Required. Derives a stable string key per row. No `index` fallback — reordering / pagination would silently desync React keys. |
+| `loading` | `boolean` | `false` | Replaces the body with `loadingMessage`. |
+| `loadingMessage` | `ReactNode` | `"Loading…"` | Shown while `loading` is true. |
+| `emptyMessage` | `ReactNode` | `"No data"` | Shown when `dataSource` is empty and not loading. |
+| `caption` | `ReactNode` | — | Rendered inside `<caption>`. |
+| `rowClassName` | `ClassValue \| (record, index) => ClassValue` | — | Per-row className. |
+| `onRowClick` | `(record, index) => void` | — | Makes rows focusable (`tabIndex=0`) and responsive to click / Enter / Space. Native `role="row"` is preserved (no override). Selection-cell events do not bubble. |
+| `selectable` | `boolean` | `false` | Enable the selection column. |
+| `selectedRowKeys` | `string[]` | — | Controlled selected keys. |
+| `defaultSelectedRowKeys` | `string[]` | `[]` | Uncontrolled initial keys. |
+| `onSelectedRowKeysChange` | `(keys, rows) => void` | — | Called with the next keys and the matching records. |
+| `getCheckboxProps` | `(record, index) => Partial<ComponentProps<typeof CheckboxRoot>>` | — | Per-row Checkbox props (base-ui `Checkbox.Root` shape — typically `disabled`, `aria-label`, `data-*`; see [Base UI Checkbox](https://base-ui.com/react/components/checkbox)). `disabled: true` gates the row out of "select all". `checked` / `onCheckedChange` are ignored — Table owns them. |
+| `selectionColumnClassName` | `ClassValue` | — | className for the selection column's `th` and `td`. |
+| `selectionColumnLabel` | `string` | `"Selection"` | Visually-hidden column name for the selection `<th>` (announced before "Select all" by screen readers). |
+| `headerClassName` | `ClassValue` | — | className on `<thead>`. |
+| `bodyClassName` | `ClassValue` | — | className on `<tbody>`. |
+| `captionClassName` | `ClassValue` | — | className on `<caption>`. |
+| `emptyClassName` | `ClassValue` | — | className on the empty-state cell. |
+| `loadingClassName` | `ClassValue` | — | className on the loading-state cell. |
+| `className` | `ClassValue` | — | className on the `<table>` element. |
+
+### `TableColumn<T>`
+
+A discriminated union by `dataIndex`. When `dataIndex` is set to a `keyof T`, `render`'s `value` is narrowed to `T[dataIndex]` automatically — no casts needed.
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `key` | `string` | Stable identifier and React key. |
+| `title` | `ReactNode` | Header content. |
+| `dataIndex` | `keyof T \| undefined` | **Top-level `keyof T` only.** Nested paths like `"user.name"` are intentionally unsupported — use `render: (_, record) => record.user.name` for deep access. |
+| `render` | `(value, record, index) => ReactNode` | Cell formatter. `value` is `T[dataIndex]` when `dataIndex` is set, otherwise `undefined`. |
+| `align` | `"left" \| "center" \| "right"` | Text alignment for `th` + `td`. |
+| `width` | `number \| string` | Emitted as inline `style.width`. |
+| `className` | `ClassValue` | Applied to both `th` and `td`. |
+| `headClassName` | `ClassValue` | Applied only to the header cell. |
+| `cellClassName` | `ClassValue` | Applied only to body cells. |
+
+## When to use the primitive instead
+
+This component covers `columns` + `dataSource` + `rowKey` + selection + loading / empty / caption / row className. Anything else is intentionally out of scope:
+
+- **Sorting, filtering, pagination** — derive these in your parent and feed `dataSource`. Combine with `@tanstack/react-table` if you want batteries included.
+- **Fixed columns / sticky headers, expandable rows, drag-to-reorder, column resize, virtualization** — composition territory.
+- **Error state** — the Table has `loading` and `emptyMessage` but no `errorMessage`. Rows aren't symmetric to a single async load, so the error UX is the parent's responsibility. Render your own error block above the Table (or swap the Table for an error block) when fetching fails.
+- **Per-row loading** (one row showing a saving spinner while others stay live) — render the spinner inside a cell via `render`. Table-wide `loading` is all-or-nothing.
+
+`onRowClick` puts every row in the Tab sequence; that's fine up to 20–30 interactive rows. For larger interactive tables you want a roving-tabindex grid pattern, which is also out of scope — reach for `@tanstack/react-table` and compose the shadcn primitives directly.
+
+For any of the above, drop down to `components/ui/table` and compose `<Table>`, `<TableHeader>`, `<TableBody>`, `<TableRow>`, `<TableHead>`, `<TableCell>`, `<TableCaption>` yourself.
+
+### Server components
+
+This component is `"use client"` — selection state, focus management and dev warnings all need the client runtime. A purely static read-only table (just `columns` + `dataSource` + `rowKey` + `caption` + a string `rowClassName`) doesn't strictly need that, but the Table forces CSR anyway. In an RSC page, either accept the client boundary, or drop down to `components/ui/table` primitives directly for the static case.

--- a/registry.json
+++ b/registry.json
@@ -166,6 +166,20 @@
           "target": "components/easy/select.tsx"
         }
       ]
+    },
+    {
+      "name": "table",
+      "type": "registry:component",
+      "title": "Integrated Table",
+      "description": "Flat-props Table with columns + dataSource + rowKey, plus loading, empty, caption, function-form rowClassName, and built-in row selection (controlled / uncontrolled, with per-row gating and indeterminate select-all).",
+      "registryDependencies": ["table", "checkbox"],
+      "files": [
+        {
+          "path": "registry/ui/table.tsx",
+          "type": "registry:component",
+          "target": "components/easy/table.tsx"
+        }
+      ]
     }
   ]
 }

--- a/registry/ui/table.test.tsx
+++ b/registry/ui/table.test.tsx
@@ -1,0 +1,1448 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { useState } from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  expectTypeOf,
+  it,
+  vi,
+} from "vitest";
+import { defineColumns, Table, type TableColumn } from "./table";
+
+interface User {
+  age: number;
+  id: string;
+  name: string;
+}
+
+const USERS: User[] = [
+  { age: 30, id: "u1", name: "Ada" },
+  { age: 45, id: "u2", name: "Linus" },
+  { age: 25, id: "u3", name: "Grace" },
+];
+
+const BASIC_COLUMNS: TableColumn<User>[] = [
+  { dataIndex: "name", key: "name", title: "Name" },
+  { dataIndex: "age", key: "age", title: "Age" },
+];
+
+const DUP_KEYS_RE = /Duplicate row keys/;
+const DUP_COL_KEYS_RE = /Duplicate column keys/;
+const NO_NAME_RE = /No accessible name/;
+const BOTH_SELECTED_RE = /Both `selectedRowKeys`/;
+const NULLISH_KEY_RE = /resolved to null or undefined/;
+const SYMBOL_KEY_RE = /resolved to a Symbol/;
+const CONTROLLED_SWITCH_RE = /switched from .* to /;
+
+function getBodyRows() {
+  // tbody is the last rowgroup (thead is the first). Using role="row" verifies
+  // that onRowClick rows preserve their implicit table-row semantics — we no
+  // longer override with role="button" (W3C ARIA APG grid pattern).
+  const rowgroups = screen.getAllByRole("rowgroup");
+  const tbody = rowgroups.at(-1) as HTMLElement;
+  return within(tbody).queryAllByRole("row");
+}
+
+describe("Table", () => {
+  it("renders one <th> per column and one <tr> per data row", () => {
+    render(<Table columns={BASIC_COLUMNS} dataSource={USERS} rowKey="id" />);
+    expect(screen.getAllByRole("columnheader")).toHaveLength(2);
+    expect(getBodyRows()).toHaveLength(3);
+    expect(screen.getByText("Ada")).toBeTruthy();
+    expect(screen.getByText("45")).toBeTruthy();
+  });
+
+  it("derives row key from a string field (rows render in source order)", () => {
+    const { container } = render(
+      <Table columns={BASIC_COLUMNS} dataSource={USERS} rowKey="id" />
+    );
+    const firstName = container.querySelector(
+      "tbody tr:first-child td"
+    )?.textContent;
+    expect(firstName).toBe("Ada");
+  });
+
+  it("derives row key from a function — emitted keys reflect the function output", () => {
+    const onSelect = vi.fn();
+    render(
+      <Table
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        onSelectedRowKeysChange={onSelect}
+        rowKey={(r) => `k-${r.id}`}
+        selectable
+      />
+    );
+    const checkboxes = screen.getAllByRole("checkbox");
+    // index 0 is header "select all"; index 1 is first body row.
+    fireEvent.click(checkboxes[1]);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][0]).toEqual(["k-u1"]);
+    expect(onSelect.mock.calls[0][1]).toEqual([USERS[0]]);
+  });
+
+  it("calls column.render with (value, record, index) and renders the result", () => {
+    const renderFn = vi.fn(
+      (value, record: User, index) => `${index}:${record.name}=${String(value)}`
+    );
+    const columns: TableColumn<User>[] = [
+      { dataIndex: "name", key: "name", render: renderFn, title: "Name" },
+    ];
+    render(<Table columns={columns} dataSource={USERS} rowKey="id" />);
+    expect(renderFn).toHaveBeenCalledWith("Ada", USERS[0], 0);
+    expect(screen.getByText("0:Ada=Ada")).toBeTruthy();
+    expect(screen.getByText("2:Grace=Grace")).toBeTruthy();
+  });
+
+  it("shows loadingMessage and hides emptyMessage when loading", () => {
+    render(
+      <Table
+        columns={BASIC_COLUMNS}
+        dataSource={[]}
+        emptyMessage="EMPTY"
+        loading
+        loadingMessage="LOADING"
+        rowKey="id"
+      />
+    );
+    expect(screen.getByText("LOADING")).toBeTruthy();
+    expect(screen.queryByText("EMPTY")).toBeNull();
+  });
+
+  it("shows emptyMessage when dataSource is empty and not loading", () => {
+    render(
+      <Table
+        columns={BASIC_COLUMNS}
+        dataSource={[]}
+        emptyMessage="Nothing here"
+        rowKey="id"
+      />
+    );
+    expect(screen.getByText("Nothing here")).toBeTruthy();
+  });
+
+  it("applies function-form rowClassName to each <tr>", () => {
+    render(
+      <Table
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        rowClassName={(r) => (r.age >= 40 ? "row-old" : "row-young")}
+        rowKey="id"
+      />
+    );
+    const rows = getBodyRows();
+    expect(rows[0].className).toContain("row-young");
+    expect(rows[1].className).toContain("row-old");
+    expect(rows[2].className).toContain("row-young");
+  });
+
+  it("selection: clicking a row checkbox fires onSelectedRowKeysChange(keys, rows)", () => {
+    const onChange = vi.fn();
+    render(
+      <Table
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        onSelectedRowKeysChange={onChange}
+        rowKey="id"
+        selectable
+      />
+    );
+    const checkboxes = screen.getAllByRole("checkbox");
+    fireEvent.click(checkboxes[2]); // second body row (u2)
+    expect(onChange).toHaveBeenCalledWith(["u2"], [USERS[1]]);
+  });
+
+  it("selection: header checkbox is indeterminate when a proper non-empty subset is selected", () => {
+    function Harness() {
+      const [keys, setKeys] = useState<string[]>(["u1"]);
+      return (
+        <Table
+          columns={BASIC_COLUMNS}
+          dataSource={USERS}
+          onSelectedRowKeysChange={setKeys}
+          rowKey="id"
+          selectable
+          selectedRowKeys={keys}
+        />
+      );
+    }
+    render(<Harness />);
+    const checkboxes = screen.getAllByRole("checkbox");
+    const header = checkboxes[0];
+    // base-ui marks the indeterminate state via aria-checked="mixed".
+    expect(header.getAttribute("aria-checked")).toBe("mixed");
+  });
+
+  it("selection: header toggles all selectable rows, skipping disabled rows", () => {
+    const onChange = vi.fn();
+    render(
+      <Table
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        getCheckboxProps={(r) => ({ disabled: r.id === "u1" })}
+        onSelectedRowKeysChange={onChange}
+        rowKey="id"
+        selectable
+      />
+    );
+    const checkboxes = screen.getAllByRole("checkbox");
+    fireEvent.click(checkboxes[0]); // header "select all"
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const [keys, rows] = onChange.mock.calls[0];
+    expect(keys).toEqual(["u2", "u3"]);
+    expect(rows).toEqual([USERS[1], USERS[2]]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Selection — uncontrolled / controlled / cycle
+  // ---------------------------------------------------------------------------
+
+  it("selection (uncontrolled): defaultSelectedRowKeys seeds initial state and reflects in UI", () => {
+    render(
+      <Table
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        defaultSelectedRowKeys={["u2"]}
+        rowKey="id"
+        selectable
+      />
+    );
+    const checkboxes = screen.getAllByRole("checkbox");
+    // index 0 = header, 1=u1, 2=u2, 3=u3
+    expect(checkboxes[2].getAttribute("aria-checked")).toBe("true");
+    expect(checkboxes[1].getAttribute("aria-checked")).toBe("false");
+    expect(checkboxes[3].getAttribute("aria-checked")).toBe("false");
+    // Header should be indeterminate (mixed) — 1 of 3 selected.
+    expect(checkboxes[0].getAttribute("aria-checked")).toBe("mixed");
+  });
+
+  it("selection (controlled): external selectedRowKeys updates drive the UI", () => {
+    function Harness() {
+      const [keys, setKeys] = useState<string[]>([]);
+      return (
+        <>
+          <button onClick={() => setKeys(["u1", "u3"])} type="button">
+            external set
+          </button>
+          <Table
+            columns={BASIC_COLUMNS}
+            dataSource={USERS}
+            rowKey="id"
+            selectable
+            selectedRowKeys={keys}
+          />
+        </>
+      );
+    }
+    render(<Harness />);
+    // Initially nothing checked.
+    let checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes[1].getAttribute("aria-checked")).toBe("false");
+    expect(checkboxes[3].getAttribute("aria-checked")).toBe("false");
+    // Drive selection externally.
+    fireEvent.click(screen.getByRole("button", { name: "external set" }));
+    checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes[1].getAttribute("aria-checked")).toBe("true");
+    expect(checkboxes[2].getAttribute("aria-checked")).toBe("false");
+    expect(checkboxes[3].getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("selection: select-all → unselect-all cycle yields ([all], [])", () => {
+    const onChange = vi.fn();
+    function Harness() {
+      const [keys, setKeys] = useState<string[]>([]);
+      return (
+        <Table
+          columns={BASIC_COLUMNS}
+          dataSource={USERS}
+          onSelectedRowKeysChange={(k, r) => {
+            onChange(k, r);
+            setKeys(k);
+          }}
+          rowKey="id"
+          selectable
+          selectedRowKeys={keys}
+        />
+      );
+    }
+    render(<Harness />);
+    const header = () => screen.getAllByRole("checkbox")[0];
+    fireEvent.click(header()); // select all
+    expect(onChange).toHaveBeenLastCalledWith(["u1", "u2", "u3"], USERS);
+    fireEvent.click(header()); // unselect all
+    expect(onChange).toHaveBeenLastCalledWith([], []);
+    // UI confirms.
+    const cbs = screen.getAllByRole("checkbox");
+    expect(cbs[1].getAttribute("aria-checked")).toBe("false");
+    expect(cbs[2].getAttribute("aria-checked")).toBe("false");
+    expect(cbs[3].getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("selection: toggling one row's checkbox does not affect siblings", () => {
+    const onChange = vi.fn();
+    function Harness() {
+      const [keys, setKeys] = useState<string[]>(["u1"]);
+      return (
+        <Table
+          columns={BASIC_COLUMNS}
+          dataSource={USERS}
+          onSelectedRowKeysChange={(k, r) => {
+            onChange(k, r);
+            setKeys(k);
+          }}
+          rowKey="id"
+          selectable
+          selectedRowKeys={keys}
+        />
+      );
+    }
+    render(<Harness />);
+    const checkboxes = screen.getAllByRole("checkbox");
+    fireEvent.click(checkboxes[3]); // toggle u3 on
+    expect(onChange).toHaveBeenLastCalledWith(
+      ["u1", "u3"],
+      [USERS[0], USERS[2]]
+    );
+    const after = screen.getAllByRole("checkbox");
+    expect(after[1].getAttribute("aria-checked")).toBe("true"); // u1 untouched
+    expect(after[2].getAttribute("aria-checked")).toBe("false"); // u2 untouched
+    expect(after[3].getAttribute("aria-checked")).toBe("true");
+  });
+
+  // ---------------------------------------------------------------------------
+  // isRowSelectable gate
+  // ---------------------------------------------------------------------------
+
+  it("getCheckboxProps disabled rows are excluded from select-all tally", () => {
+    const onChange = vi.fn();
+    render(
+      <Table
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        getCheckboxProps={(r) => ({ disabled: r.id === "u1" })}
+        onSelectedRowKeysChange={onChange}
+        rowKey="id"
+        selectable
+      />
+    );
+    const checkboxes = screen.getAllByRole("checkbox");
+    // Per-row disabled state: u1 (index 1) is gated out. base-ui surfaces this
+    // through aria-disabled rather than a native attribute since the element
+    // is a div.
+    const isDisabled = (el: Element) =>
+      el.getAttribute("aria-disabled") === "true" ||
+      el.hasAttribute("disabled") ||
+      el.getAttribute("data-disabled") !== null;
+    expect(isDisabled(checkboxes[1])).toBe(true);
+    expect(isDisabled(checkboxes[2])).toBe(false);
+    expect(isDisabled(checkboxes[3])).toBe(false);
+    // Select-all only flips selectable subset.
+    fireEvent.click(checkboxes[0]);
+    expect(onChange).toHaveBeenCalledWith(["u2", "u3"], [USERS[1], USERS[2]]);
+    // After all selectable are selected, the header reads "all" (not "mixed").
+    const after = screen.getAllByRole("checkbox");
+    expect(after[0].getAttribute("aria-checked")).toBe("true");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Column rendering: dataIndex absent, alignment, width
+  // ---------------------------------------------------------------------------
+
+  it("column with no dataIndex and no render produces an empty cell without crashing", () => {
+    const columns: TableColumn<User>[] = [
+      { key: "name", title: "Name", dataIndex: "name" },
+      // No dataIndex, no render — should render nothing safely.
+      { key: "blank", title: "Blank" },
+    ];
+    // Spy on console.error so a React render-time crash would surface here.
+    const err = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    render(<Table columns={columns} dataSource={USERS} rowKey="id" />);
+    err.mockRestore();
+    // 3 rows × 2 columns = 6 body cells.
+    const bodyRows = getBodyRows();
+    expect(bodyRows).toHaveLength(3);
+    for (const tr of bodyRows) {
+      const cells = within(tr).getAllByRole("cell");
+      expect(cells).toHaveLength(2);
+      // Second cell is the blank one.
+      expect(cells[1].textContent).toBe("");
+    }
+  });
+
+  it("column with dataIndex missing but render present passes undefined as value", () => {
+    const renderFn = vi.fn(() => "RENDERED");
+    const columns: TableColumn<User>[] = [
+      { key: "x", title: "X", render: renderFn },
+    ];
+    render(<Table columns={columns} dataSource={[USERS[0]]} rowKey="id" />);
+    expect(renderFn).toHaveBeenCalledWith(undefined, USERS[0], 0);
+    expect(screen.getByText("RENDERED")).toBeTruthy();
+  });
+
+  it("align=center / align=right apply text-* classes to both <th> and <td>", () => {
+    const columns: TableColumn<User>[] = [
+      { align: "center", dataIndex: "name", key: "name", title: "Name" },
+      { align: "right", dataIndex: "age", key: "age", title: "Age" },
+    ];
+    const { container } = render(
+      <Table columns={columns} dataSource={USERS} rowKey="id" />
+    );
+    const ths = container.querySelectorAll("thead th");
+    expect(ths[0].className).toContain("text-center");
+    expect(ths[1].className).toContain("text-right");
+    const firstBodyRow = container.querySelector("tbody tr");
+    const tds = firstBodyRow?.querySelectorAll("td") ?? [];
+    expect(tds[0].className).toContain("text-center");
+    expect(tds[1].className).toContain("text-right");
+  });
+
+  it("width=number is emitted as inline style on <th> and <td>", () => {
+    const columns: TableColumn<User>[] = [
+      { dataIndex: "name", key: "name", title: "Name", width: 120 },
+      { dataIndex: "age", key: "age", title: "Age", width: "20%" },
+    ];
+    const { container } = render(
+      <Table columns={columns} dataSource={USERS} rowKey="id" />
+    );
+    const ths = container.querySelectorAll("thead th");
+    // React serializes number→px on the style attribute.
+    expect((ths[0] as HTMLElement).style.width).toBe("120px");
+    expect((ths[1] as HTMLElement).style.width).toBe("20%");
+    const firstRowTds = container.querySelectorAll("tbody tr:first-child td");
+    expect((firstRowTds[0] as HTMLElement).style.width).toBe("120px");
+    expect((firstRowTds[1] as HTMLElement).style.width).toBe("20%");
+  });
+
+  // ---------------------------------------------------------------------------
+  // *ClassName passthrough
+  // ---------------------------------------------------------------------------
+
+  it("passes headerClassName / bodyClassName / captionClassName through to thead / tbody / caption", () => {
+    const { container } = render(
+      <Table
+        bodyClassName="my-body"
+        caption="Hello"
+        captionClassName="my-caption"
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        headerClassName="my-header"
+        rowKey="id"
+      />
+    );
+    expect(container.querySelector("thead")?.className).toContain("my-header");
+    expect(container.querySelector("tbody")?.className).toContain("my-body");
+    expect(container.querySelector("caption")?.className).toContain(
+      "my-caption"
+    );
+    expect(container.querySelector("caption")?.textContent).toBe("Hello");
+  });
+
+  it("passes string rowClassName to every <tr>", () => {
+    render(
+      <Table
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        rowClassName="my-row"
+        rowKey="id"
+      />
+    );
+    for (const tr of getBodyRows()) {
+      expect(tr.className).toContain("my-row");
+    }
+  });
+
+  it("passes emptyClassName / loadingClassName to the placeholder cell", () => {
+    const { rerender, container } = render(
+      <Table
+        columns={BASIC_COLUMNS}
+        dataSource={[]}
+        emptyClassName="my-empty"
+        rowKey="id"
+      />
+    );
+    expect(container.querySelector("tbody td")?.className).toContain(
+      "my-empty"
+    );
+    rerender(
+      <Table
+        columns={BASIC_COLUMNS}
+        dataSource={[]}
+        loading
+        loadingClassName="my-loading"
+        rowKey="id"
+      />
+    );
+    expect(container.querySelector("tbody td")?.className).toContain(
+      "my-loading"
+    );
+  });
+
+  it("passes selectionColumnClassName to selection <th> and every selection <td>", () => {
+    const { container } = render(
+      <Table
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        rowKey="id"
+        selectable
+        selectionColumnClassName="my-sel"
+      />
+    );
+    const selHead = container.querySelector(
+      '[data-slot="easy-table-selection-head"]'
+    );
+    expect(selHead?.className).toContain("my-sel");
+    const selCells = container.querySelectorAll(
+      '[data-slot="easy-table-selection-cell"]'
+    );
+    expect(selCells).toHaveLength(USERS.length);
+    for (const cell of selCells) {
+      expect(cell.className).toContain("my-sel");
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Duplicate rowKey dev warning
+  // ---------------------------------------------------------------------------
+
+  describe("duplicate rowKey warning", () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    });
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    const countCallsMatching = (re: RegExp) =>
+      warnSpy.mock.calls.filter((c) => re.test(String(c[0]))).length;
+
+    it("warns once when keys collide (same fingerprint = no spam)", () => {
+      const dupes: User[] = [
+        { age: 1, id: "dup", name: "A" },
+        { age: 2, id: "dup", name: "B" },
+      ];
+      const { rerender } = render(
+        // `caption` keeps the unrelated "no accessible name" warn quiet so
+        // this assertion stays scoped to the duplicate-key warning.
+        <Table
+          caption="Users"
+          columns={BASIC_COLUMNS}
+          dataSource={dupes}
+          rowKey="id"
+        />
+      );
+      expect(countCallsMatching(DUP_KEYS_RE)).toBe(1);
+      // Re-render with the same dupes — same fingerprint, no spam.
+      rerender(
+        <Table
+          caption="Users"
+          columns={BASIC_COLUMNS}
+          dataSource={[...dupes]}
+          rowKey="id"
+        />
+      );
+      expect(countCallsMatching(DUP_KEYS_RE)).toBe(1);
+    });
+
+    it("re-warns when dataSource mutates into a *different* dup fingerprint", () => {
+      const clean: User[] = [
+        { age: 1, id: "u1", name: "A" },
+        { age: 2, id: "u2", name: "B" },
+      ];
+      const dupesA: User[] = [
+        { age: 1, id: "u1", name: "A" },
+        { age: 2, id: "u1", name: "B" },
+      ];
+      const dupesB: User[] = [
+        { age: 1, id: "u9", name: "X" },
+        { age: 2, id: "u9", name: "Y" },
+      ];
+      const { rerender } = render(
+        <Table
+          caption="Users"
+          columns={BASIC_COLUMNS}
+          dataSource={clean}
+          rowKey="id"
+        />
+      );
+      // 1. Mount without dupes — no warn.
+      expect(countCallsMatching(DUP_KEYS_RE)).toBe(0);
+      // 2. Switch to dupes A — warn once.
+      rerender(
+        <Table
+          caption="Users"
+          columns={BASIC_COLUMNS}
+          dataSource={dupesA}
+          rowKey="id"
+        />
+      );
+      expect(countCallsMatching(DUP_KEYS_RE)).toBe(1);
+      // 3. Switch to dupes B (different fingerprint) — warn again.
+      rerender(
+        <Table
+          caption="Users"
+          columns={BASIC_COLUMNS}
+          dataSource={dupesB}
+          rowKey="id"
+        />
+      );
+      expect(countCallsMatching(DUP_KEYS_RE)).toBe(2);
+      // 4. Switch back to dupes A (already-seen fingerprint) — no new warn.
+      rerender(
+        <Table
+          caption="Users"
+          columns={BASIC_COLUMNS}
+          dataSource={dupesA}
+          rowKey="id"
+        />
+      );
+      expect(countCallsMatching(DUP_KEYS_RE)).toBe(2);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Accessibility — keyboard interaction
+  // ---------------------------------------------------------------------------
+
+  it("a11y: row checkboxes have role=checkbox and aria-checked tracks state", () => {
+    function Harness() {
+      const [keys, setKeys] = useState<string[]>([]);
+      return (
+        <Table
+          columns={BASIC_COLUMNS}
+          dataSource={USERS}
+          onSelectedRowKeysChange={setKeys}
+          rowKey="id"
+          selectable
+          selectedRowKeys={keys}
+        />
+      );
+    }
+    render(<Harness />);
+    // All row + header checkboxes are exposed via role=checkbox.
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes).toHaveLength(USERS.length + 1);
+    // Pre-click: all unchecked.
+    for (const cb of checkboxes.slice(1)) {
+      expect(cb.getAttribute("aria-checked")).toBe("false");
+    }
+    // Activate (click is the synchronous keyboard-equivalent in base-ui — Space
+    // dispatches a click via useButton, but jsdom does not bridge keydown→click).
+    fireEvent.click(checkboxes[1]);
+    const after = screen.getAllByRole("checkbox");
+    expect(after[1].getAttribute("aria-checked")).toBe("true");
+    // Each row checkbox carries a descriptive aria-label.
+    expect(after[1].getAttribute("aria-label")).toBe("Select row u1");
+    // Header carries the bulk-action aria-label.
+    expect(after[0].getAttribute("aria-label")).toBe("Select all rows");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Type-level checks — dataIndex must be keyof T
+  // ---------------------------------------------------------------------------
+
+  it("type: dataIndex is constrained to keyof T (compile-time)", () => {
+    expectTypeOf<TableColumn<User>["dataIndex"]>().toEqualTypeOf<
+      keyof User | undefined
+    >();
+
+    // Sanity: valid column compiles.
+    const ok: TableColumn<User> = {
+      dataIndex: "name",
+      key: "name",
+      title: "Name",
+    };
+    expect(ok.key).toBe("name");
+  });
+
+  it("type: defineColumns narrows render value and rejects invalid dataIndex", () => {
+    // Prove narrowing reached `number` (not `any` / union) by exercising
+    // number-only methods inside render and capturing the inferred parameter.
+    let capturedAge: number | undefined;
+    const cols = defineColumns<User>()([
+      {
+        dataIndex: "age",
+        key: "age",
+        render: (value) => {
+          // If narrowing failed, `value` would be `any` and `toFixed` would
+          // type-check, BUT `expectTypeOf` below would catch the regression.
+          capturedAge = value;
+          return value.toFixed(0);
+        },
+        title: "Age",
+      },
+    ]);
+    expect(cols[0].key).toBe("age");
+    expect(capturedAge).toBeUndefined(); // render not invoked yet
+
+    // Type-level: the first column's `dataIndex` is the literal "age".
+    expectTypeOf<(typeof cols)[0]["dataIndex"]>().toEqualTypeOf<"age">();
+
+    // Invalid dataIndex must be rejected at the builder call. If TS ever loses
+    // narrowing in this file, the @ts-expect-error becomes unused and the suite
+    // fails fast.
+    defineColumns<User>()([
+      // @ts-expect-error — "nope" is not keyof User
+      { dataIndex: "nope", key: "x", title: "X" },
+    ]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Indeterminate visual (Round 1 fix)
+  // ---------------------------------------------------------------------------
+
+  it("indeterminate header renders the dash icon, not the tick", () => {
+    // Drive selectedRowKeys directly through props so rerender updates apply.
+    const { container, rerender } = render(
+      <Table
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        rowKey="id"
+        selectable
+        selectedRowKeys={["u1"]}
+      />
+    );
+    // 1 of 3 selected → indeterminate dash.
+    let headerIcon = container.querySelector(
+      '[data-slot="easy-table-selection-head"] [data-icon]'
+    );
+    expect(headerIcon?.getAttribute("data-icon")).toBe("indeterminate");
+
+    // All 3 of 3 selected → checked tick.
+    rerender(
+      <Table
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        rowKey="id"
+        selectable
+        selectedRowKeys={["u1", "u2", "u3"]}
+      />
+    );
+    headerIcon = container.querySelector(
+      '[data-slot="easy-table-selection-head"] [data-icon]'
+    );
+    expect(headerIcon?.getAttribute("data-icon")).toBe("checked");
+  });
+
+  // -------------------------------------------------------------------------
+  // Round 6 regression — Checkbox.Indicator must NOT render while unchecked.
+  // Adding `keepMounted` to the Indicator forced the tick SVG into the DOM
+  // for empty rows, which read visually as "checked, transparent theme" and
+  // broke every selection demo. These assertions lock the fix.
+  // -------------------------------------------------------------------------
+
+  it("unchecked: zero rows selected → no indicator in any row or header", () => {
+    const { container } = render(
+      <Table
+        caption="Empty selection"
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        rowKey="id"
+        selectable
+      />
+    );
+    // No tick / dash icon should be reachable anywhere in the selection column
+    // when nothing is selected.
+    const icons = container.querySelectorAll(
+      '[data-slot="easy-table-selection-head"] [data-icon], [data-slot="easy-table-selection-cell"] [data-icon]'
+    );
+    expect(icons).toHaveLength(0);
+    const indicators = container.querySelectorAll(
+      '[data-slot="easy-table-selection-indicator"]'
+    );
+    expect(indicators).toHaveLength(0);
+  });
+
+  it("partial selection: only selected rows show an indicator; others have none", () => {
+    const { container } = render(
+      <Table
+        caption="Partial selection"
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        rowKey="id"
+        selectable
+        selectedRowKeys={["u2"]}
+      />
+    );
+    // Header → indeterminate (1 of 3).
+    const headerIcon = container.querySelector(
+      '[data-slot="easy-table-selection-head"] [data-icon]'
+    );
+    expect(headerIcon?.getAttribute("data-icon")).toBe("indeterminate");
+    // Body → exactly one indicator, in the u2 row, of kind "checked".
+    const bodyIcons = container.querySelectorAll(
+      '[data-slot="easy-table-selection-cell"] [data-icon]'
+    );
+    expect(bodyIcons).toHaveLength(1);
+    expect(bodyIcons[0].getAttribute("data-icon")).toBe("checked");
+  });
+
+  it("full selection: every row shows a tick; header shows tick (not dash)", () => {
+    const { container } = render(
+      <Table
+        caption="Full selection"
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        rowKey="id"
+        selectable
+        selectedRowKeys={["u1", "u2", "u3"]}
+      />
+    );
+    const headerIcon = container.querySelector(
+      '[data-slot="easy-table-selection-head"] [data-icon]'
+    );
+    expect(headerIcon?.getAttribute("data-icon")).toBe("checked");
+    const bodyIcons = container.querySelectorAll(
+      '[data-slot="easy-table-selection-cell"] [data-icon]'
+    );
+    expect(bodyIcons).toHaveLength(USERS.length);
+    for (const icon of bodyIcons) {
+      expect(icon.getAttribute("data-icon")).toBe("checked");
+    }
+  });
+
+  it("disabled-by-getCheckboxProps row is unchecked and has no indicator", () => {
+    const { container } = render(
+      <Table
+        caption="Owner non-selectable"
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        getCheckboxProps={(r) => ({ disabled: r.id === "u1" })}
+        rowKey="id"
+        selectable
+        // Select u2 so the partial state mirrors the user-screenshot scenario.
+        selectedRowKeys={["u2"]}
+      />
+    );
+    const cells = container.querySelectorAll(
+      '[data-slot="easy-table-selection-cell"]'
+    );
+    // First cell is u1, disabled; should NOT carry an indicator.
+    expect(cells[0].querySelector("[data-icon]")).toBeNull();
+    // Second cell is u2, selected; SHOULD carry a "checked" indicator.
+    expect(
+      cells[1].querySelector("[data-icon]")?.getAttribute("data-icon")
+    ).toBe("checked");
+    // Third cell is u3, unselected & enabled; no indicator.
+    expect(cells[2].querySelector("[data-icon]")).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Round 7 — disabled checkbox visual must be distinguishable.
+  // The previous default (`disabled:opacity-50`) was almost invisible on an
+  // already-faint unchecked outline. Lock in the grey-fill + soft-border
+  // tokens so a future "tidy-up" doesn't quietly revert the contrast.
+  // -------------------------------------------------------------------------
+
+  it("disabled checkbox carries data-disabled and the high-contrast disabled tokens", () => {
+    const { container } = render(
+      <Table
+        caption="Disabled visual"
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        getCheckboxProps={(r) => ({ disabled: r.id === "u1" })}
+        rowKey="id"
+        selectable
+      />
+    );
+    const cb = container.querySelector(
+      '[data-slot="easy-table-selection-cell"] [data-slot="easy-table-selection-checkbox"]'
+    );
+    expect(cb).not.toBeNull();
+    // base-ui surfaces disabled state via data-disabled attribute.
+    expect(cb?.getAttribute("data-disabled")).not.toBeNull();
+    // Class string must carry the new disabled-state tokens so the visual
+    // difference vs an enabled-unchecked checkbox is unmistakable. We assert
+    // on tokens, not exact ordering, so unrelated tailwind tweaks don't break
+    // this guard.
+    const cls = cb?.className ?? "";
+    expect(cls).toContain("disabled:bg-muted");
+    expect(cls).toContain("disabled:border-muted-foreground/30");
+    expect(cls).toContain("disabled:cursor-not-allowed");
+    // The old weak token must NOT be re-introduced — that was the regression.
+    expect(cls).not.toContain("disabled:opacity-50");
+  });
+
+  it("checked-disabled checkbox keeps primary fill (data-checked beats data-disabled in the cascade)", () => {
+    const { container } = render(
+      <Table
+        caption="Checked + disabled"
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        // u1 is BOTH selected and disabled — covers the "forced selection,
+        // not deselectable" UX pattern.
+        getCheckboxProps={(r) => ({ disabled: r.id === "u1" })}
+        rowKey="id"
+        selectable
+        selectedRowKeys={["u1"]}
+      />
+    );
+    const cells = container.querySelectorAll(
+      '[data-slot="easy-table-selection-cell"]'
+    );
+    const u1Cb = cells[0].querySelector(
+      '[data-slot="easy-table-selection-checkbox"]'
+    );
+    // Visually shows the tick: indicator + data-icon="checked" present.
+    expect(u1Cb?.querySelector('[data-icon="checked"]')).not.toBeNull();
+    // Still flagged disabled.
+    expect(u1Cb?.getAttribute("data-disabled")).not.toBeNull();
+    // The cascade must give us BOTH tokens — checked fills win at render,
+    // disabled cursor / border still communicate the gated state.
+    const cls = u1Cb?.className ?? "";
+    expect(cls).toContain("data-checked:bg-primary");
+    expect(cls).toContain("disabled:cursor-not-allowed");
+  });
+
+  // ---------------------------------------------------------------------------
+  // getCheckboxProps passthrough
+  // ---------------------------------------------------------------------------
+
+  it("getCheckboxProps: arbitrary props (data-*, aria-*) pass through to the row Checkbox", () => {
+    const { container } = render(
+      <Table
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        getCheckboxProps={(r) => ({
+          "aria-label": `cb-${r.id}`,
+          "data-row": r.id,
+        })}
+        rowKey="id"
+        selectable
+      />
+    );
+    const u1Cb = container.querySelector('[data-row="u1"]');
+    expect(u1Cb).not.toBeNull();
+    expect(u1Cb?.getAttribute("aria-label")).toBe("cb-u1");
+  });
+
+  it("getCheckboxProps: external checked/onCheckedChange are ignored — Table owns them", () => {
+    const externalOnChange = vi.fn();
+    const onChange = vi.fn();
+    render(
+      <Table
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        getCheckboxProps={() => ({
+          checked: true,
+          onCheckedChange: externalOnChange,
+        })}
+        onSelectedRowKeysChange={onChange}
+        rowKey="id"
+        selectable
+      />
+    );
+    const checkboxes = screen.getAllByRole("checkbox");
+    // Despite getCheckboxProps insisting `checked: true`, Table owns state and
+    // shows them all as unchecked.
+    expect(checkboxes[1].getAttribute("aria-checked")).toBe("false");
+    fireEvent.click(checkboxes[1]);
+    // Table's own handler fired; external one did not.
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(externalOnChange).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // onRowClick + keyboard a11y
+  // ---------------------------------------------------------------------------
+
+  it("onRowClick: mouse click on a row fires the handler with (record, index)", () => {
+    const onRowClick = vi.fn();
+    render(
+      <Table
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        onRowClick={onRowClick}
+        rowKey="id"
+      />
+    );
+    const rows = getBodyRows();
+    // Implicit role="row" is preserved (NOT overridden to "button") so screen
+    // readers still report this as a table cell row.
+    expect(rows[1].tagName).toBe("TR");
+    expect(rows[1].getAttribute("role")).toBeNull();
+    expect(rows[1].getAttribute("tabindex")).toBe("0");
+    fireEvent.click(rows[1]);
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+    expect(onRowClick).toHaveBeenCalledWith(USERS[1], 1);
+  });
+
+  it("onRowClick: Enter and Space both trigger; Space preventDefaults page-scroll", () => {
+    const onRowClick = vi.fn();
+    render(
+      <Table
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        onRowClick={onRowClick}
+        rowKey="id"
+      />
+    );
+    const rows = getBodyRows();
+    fireEvent.keyDown(rows[0], { key: "Enter" });
+    expect(onRowClick).toHaveBeenLastCalledWith(USERS[0], 0);
+    // Construct a real KeyboardEvent so we can inspect defaultPrevented after
+    // dispatch. fireEvent.keyDown with a plain object cannot prove preventDefault
+    // was called by the handler.
+    const spaceEvent = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: " ",
+    });
+    rows[2].dispatchEvent(spaceEvent);
+    expect(onRowClick).toHaveBeenLastCalledWith(USERS[2], 2);
+    expect(onRowClick).toHaveBeenCalledTimes(2);
+    expect(spaceEvent.defaultPrevented).toBe(true);
+  });
+
+  it("onRowClick: keys other than Enter / Space do not fire the handler", () => {
+    const onRowClick = vi.fn();
+    render(
+      <Table
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        onRowClick={onRowClick}
+        rowKey="id"
+      />
+    );
+    const rows = getBodyRows();
+    fireEvent.keyDown(rows[0], { key: "a" });
+    fireEvent.keyDown(rows[0], { key: "Tab" });
+    fireEvent.keyDown(rows[0], { key: "ArrowDown" });
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it("onRowClick: clicks inside the selection cell do not bubble to the row handler", () => {
+    const onRowClick = vi.fn();
+    const onSelect = vi.fn();
+    render(
+      <Table
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        onRowClick={onRowClick}
+        onSelectedRowKeysChange={onSelect}
+        rowKey="id"
+        selectable
+      />
+    );
+    const checkboxes = screen.getAllByRole("checkbox");
+    fireEvent.click(checkboxes[1]); // first row's checkbox
+    // Selection handler fires; row handler does NOT.
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onRowClick).not.toHaveBeenCalled();
+    // Clicking the row body still triggers onRowClick.
+    const rows = getBodyRows();
+    fireEvent.click(rows[1]);
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("onRowClick: key presses inside the selection cell do not bubble to the row handler", () => {
+    const onRowClick = vi.fn();
+    render(
+      <Table
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        onRowClick={onRowClick}
+        rowKey="id"
+        selectable
+      />
+    );
+    // Dispatch an Enter keydown from inside the selection cell — it must NOT
+    // bubble up to the row's onKeyDown handler.
+    const selCell = document.querySelector(
+      '[data-slot="easy-table-selection-cell"]'
+    ) as HTMLElement;
+    expect(selCell).toBeTruthy();
+    fireEvent.keyDown(selCell, { key: "Enter" });
+    expect(onRowClick).not.toHaveBeenCalled();
+    fireEvent.keyDown(selCell, { key: " " });
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it("onRowClick absent → rows have no role/tabIndex", () => {
+    render(<Table columns={BASIC_COLUMNS} dataSource={USERS} rowKey="id" />);
+    const rows = getBodyRows();
+    expect(rows[0].getAttribute("role")).toBeNull();
+    expect(rows[0].getAttribute("tabindex")).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------------
+  // dataSource null/undefined safety (Round 1 fix)
+  // ---------------------------------------------------------------------------
+
+  it("dataSource: null/undefined treated as empty array at runtime", () => {
+    const { rerender } = render(
+      <Table
+        columns={BASIC_COLUMNS}
+        // Cast through unknown — TS would otherwise reject `null` per the
+        // signature; we still want runtime to survive accidental `null`.
+        dataSource={null as unknown as User[]}
+        emptyMessage="EMPTY"
+        rowKey="id"
+      />
+    );
+    expect(screen.getByText("EMPTY")).toBeTruthy();
+    // `undefined` is the more common SWR / React Query pre-fetch shape.
+    rerender(
+      <Table
+        columns={BASIC_COLUMNS}
+        dataSource={undefined as unknown as User[]}
+        emptyMessage="EMPTY"
+        rowKey="id"
+      />
+    );
+    expect(screen.getByText("EMPTY")).toBeTruthy();
+  });
+
+  // ---------------------------------------------------------------------------
+  // A11y — Round 4 audit fixes
+  // ---------------------------------------------------------------------------
+
+  it("a11y: <table aria-busy> reflects the `loading` prop", () => {
+    const { container, rerender } = render(
+      <Table
+        caption="Tasks"
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        rowKey="id"
+      />
+    );
+    // Default: not loading, no aria-busy attribute at all (passes truthy-only).
+    expect(container.querySelector("table")?.getAttribute("aria-busy")).toBe(
+      null
+    );
+    rerender(
+      <Table
+        caption="Tasks"
+        columns={BASIC_COLUMNS}
+        dataSource={[]}
+        loading
+        rowKey="id"
+      />
+    );
+    expect(container.querySelector("table")?.getAttribute("aria-busy")).toBe(
+      "true"
+    );
+  });
+
+  it("a11y: loading and empty cells carry role=status for SR announcement", () => {
+    const { container, rerender } = render(
+      <Table
+        caption="Tasks"
+        columns={BASIC_COLUMNS}
+        dataSource={[]}
+        emptyMessage="EMPTY"
+        rowKey="id"
+      />
+    );
+    const emptyCell = container.querySelector("tbody td[role='status']");
+    expect(emptyCell?.textContent).toBe("EMPTY");
+    rerender(
+      <Table
+        caption="Tasks"
+        columns={BASIC_COLUMNS}
+        dataSource={[]}
+        loading
+        loadingMessage="LOADING"
+        rowKey="id"
+      />
+    );
+    const loadingCell = container.querySelector("tbody td[role='status']");
+    expect(loadingCell?.textContent).toBe("LOADING");
+  });
+
+  it("a11y: selection <th> renders an SR-only column label", () => {
+    const { container } = render(
+      <Table
+        caption="Members"
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        rowKey="id"
+        selectable
+      />
+    );
+    const head = container.querySelector(
+      '[data-slot="easy-table-selection-head"]'
+    );
+    const srSpan = head?.querySelector("span.sr-only");
+    expect(srSpan?.textContent).toBe("Selection");
+  });
+
+  it("a11y: selectionColumnLabel overrides the default SR-only label", () => {
+    const { container } = render(
+      <Table
+        caption="Members"
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        rowKey="id"
+        selectable
+        selectionColumnLabel="Choose member"
+      />
+    );
+    const srSpan = container.querySelector(
+      '[data-slot="easy-table-selection-head"] span.sr-only'
+    );
+    expect(srSpan?.textContent).toBe("Choose member");
+  });
+
+  it("a11y: getCheckboxProps `aria-label` overrides the opaque default", () => {
+    const { container } = render(
+      <Table
+        caption="Members"
+        columns={BASIC_COLUMNS}
+        dataSource={USERS}
+        getCheckboxProps={(r) => ({ "aria-label": `Select ${r.name}` })}
+        rowKey="id"
+        selectable
+      />
+    );
+    const cbs = container.querySelectorAll(
+      '[data-slot="easy-table-selection-cell"] [role="checkbox"]'
+    );
+    // First body row is u1 / Ada.
+    expect(cbs[0]?.getAttribute("aria-label")).toBe("Select Ada");
+  });
+
+  describe("dev warnings: nameless table + controlled/default conflict", () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    });
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    const callsMatching = (re: RegExp) =>
+      warnSpy.mock.calls.filter((c) => re.test(String(c[0]))).length;
+
+    it("warns once when the table has no caption / aria-label / aria-labelledby", () => {
+      const { rerender } = render(
+        <Table columns={BASIC_COLUMNS} dataSource={USERS} rowKey="id" />
+      );
+      expect(callsMatching(NO_NAME_RE)).toBe(1);
+      // Subsequent renders of the same instance don't repeat.
+      rerender(
+        <Table columns={BASIC_COLUMNS} dataSource={[...USERS]} rowKey="id" />
+      );
+      expect(callsMatching(NO_NAME_RE)).toBe(1);
+    });
+
+    it("does NOT warn when caption is provided", () => {
+      render(
+        <Table
+          caption="Members"
+          columns={BASIC_COLUMNS}
+          dataSource={USERS}
+          rowKey="id"
+        />
+      );
+      expect(callsMatching(NO_NAME_RE)).toBe(0);
+    });
+
+    it("does NOT warn when aria-label is provided", () => {
+      render(
+        <Table
+          aria-label="Members"
+          columns={BASIC_COLUMNS}
+          dataSource={USERS}
+          rowKey="id"
+        />
+      );
+      expect(callsMatching(NO_NAME_RE)).toBe(0);
+    });
+
+    it("warns once when both selectedRowKeys and defaultSelectedRowKeys are passed", () => {
+      render(
+        <Table
+          caption="Members"
+          columns={BASIC_COLUMNS}
+          dataSource={USERS}
+          defaultSelectedRowKeys={["u1"]}
+          rowKey="id"
+          selectable
+          selectedRowKeys={["u2"]}
+        />
+      );
+      expect(callsMatching(BOTH_SELECTED_RE)).toBe(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Round 5 — edge cases & extra dev warnings
+  // ---------------------------------------------------------------------------
+
+  describe("rowKey value diagnostics (round 5)", () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    });
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    const callsMatching = (re: RegExp) =>
+      warnSpy.mock.calls.filter((c) => re.test(String(c[0]))).length;
+
+    it("warns when rowKey resolves to null / undefined on any row", () => {
+      type Rec = { id: string | null | undefined; name: string };
+      const rows: Rec[] = [
+        { id: "u1", name: "A" },
+        { id: null, name: "B" },
+        { id: undefined, name: "C" },
+      ];
+      render(
+        <Table
+          caption="Diag"
+          columns={[{ dataIndex: "name", key: "name", title: "Name" }]}
+          dataSource={rows}
+          rowKey="id"
+        />
+      );
+      expect(callsMatching(NULLISH_KEY_RE)).toBe(1);
+    });
+
+    it("warns when rowKey resolves to a Symbol on any row", () => {
+      type Rec = { id: string | symbol; name: string };
+      const rows: Rec[] = [
+        { id: "u1", name: "A" },
+        { id: Symbol("u2"), name: "B" },
+      ];
+      render(
+        <Table
+          caption="Diag"
+          columns={[{ dataIndex: "name", key: "name", title: "Name" }]}
+          dataSource={rows}
+          rowKey="id"
+        />
+      );
+      expect(callsMatching(SYMBOL_KEY_RE)).toBe(1);
+    });
+  });
+
+  describe("column key dedupe (round 5)", () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    });
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    const callsMatching = (re: RegExp) =>
+      warnSpy.mock.calls.filter((c) => re.test(String(c[0]))).length;
+
+    it("warns when two columns share the same key", () => {
+      const dupCols: TableColumn<User>[] = [
+        { dataIndex: "name", key: "x", title: "Name" },
+        { dataIndex: "age", key: "x", title: "Age" },
+      ];
+      render(
+        <Table
+          caption="DupCols"
+          columns={dupCols}
+          dataSource={USERS}
+          rowKey="id"
+        />
+      );
+      expect(callsMatching(DUP_COL_KEYS_RE)).toBe(1);
+    });
+
+    it("does not warn when all column keys are unique", () => {
+      render(
+        <Table
+          caption="OK"
+          columns={BASIC_COLUMNS}
+          dataSource={USERS}
+          rowKey="id"
+        />
+      );
+      expect(callsMatching(DUP_COL_KEYS_RE)).toBe(0);
+    });
+  });
+
+  describe("controlled / uncontrolled switch (round 5)", () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    });
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    const callsMatching = (re: RegExp) =>
+      warnSpy.mock.calls.filter((c) => re.test(String(c[0]))).length;
+
+    it("warns when an uncontrolled Table flips to controlled mid-life", () => {
+      const { rerender } = render(
+        <Table
+          caption="Members"
+          columns={BASIC_COLUMNS}
+          dataSource={USERS}
+          rowKey="id"
+          selectable
+        />
+      );
+      expect(callsMatching(CONTROLLED_SWITCH_RE)).toBe(0);
+      rerender(
+        <Table
+          caption="Members"
+          columns={BASIC_COLUMNS}
+          dataSource={USERS}
+          rowKey="id"
+          selectable
+          selectedRowKeys={["u1"]}
+        />
+      );
+      expect(callsMatching(CONTROLLED_SWITCH_RE)).toBe(1);
+    });
+
+    it("warns when a controlled Table flips to uncontrolled mid-life", () => {
+      const { rerender } = render(
+        <Table
+          caption="Members"
+          columns={BASIC_COLUMNS}
+          dataSource={USERS}
+          rowKey="id"
+          selectable
+          selectedRowKeys={[]}
+        />
+      );
+      expect(callsMatching(CONTROLLED_SWITCH_RE)).toBe(0);
+      rerender(
+        <Table
+          caption="Members"
+          columns={BASIC_COLUMNS}
+          dataSource={USERS}
+          rowKey="id"
+          selectable
+        />
+      );
+      expect(callsMatching(CONTROLLED_SWITCH_RE)).toBe(1);
+    });
+
+    it("no warn on stable controlled or stable uncontrolled re-renders", () => {
+      const { rerender } = render(
+        <Table
+          caption="Members"
+          columns={BASIC_COLUMNS}
+          dataSource={USERS}
+          rowKey="id"
+          selectable
+          selectedRowKeys={["u1"]}
+        />
+      );
+      rerender(
+        <Table
+          caption="Members"
+          columns={BASIC_COLUMNS}
+          dataSource={USERS}
+          rowKey="id"
+          selectable
+          selectedRowKeys={["u2"]}
+        />
+      );
+      expect(callsMatching(CONTROLLED_SWITCH_RE)).toBe(0);
+    });
+  });
+});

--- a/registry/ui/table.tsx
+++ b/registry/ui/table.tsx
@@ -1,0 +1,801 @@
+"use client";
+
+import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox";
+import { MinusSignIcon, Tick02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import type { ClassValue } from "clsx";
+import type React from "react";
+import type {
+  ComponentProps,
+  KeyboardEvent,
+  MouseEvent,
+  ReactElement,
+} from "react";
+import { useEffect, useRef, useState } from "react";
+import {
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  Table as TableRoot,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// Column types — discriminated union so `render`'s `value` narrows by
+// `dataIndex`. Writing `dataIndex: "name"` makes the cell renderer receive
+// `T["name"]` instead of `T[keyof T] | undefined`.
+// ---------------------------------------------------------------------------
+
+interface TableColumnBase {
+  /** Text alignment for both `th` and `td` of this column. */
+  align?: "left" | "center" | "right";
+  /** Applied only to body cells of this column. */
+  cellClassName?: ClassValue;
+  /** Applied to both the header cell and every body cell of this column. */
+  className?: ClassValue;
+  /** Applied only to the header cell of this column. */
+  headClassName?: ClassValue;
+  /** Stable identifier; also used as React key for the column. */
+  key: string;
+  /** Header content. */
+  title: React.ReactNode;
+  /** Column width — emitted as inline `style.width` on both `th` and `td`. */
+  width?: number | string;
+}
+
+/** Column with a `dataIndex` — `render` receives the narrowed field value. */
+export type TableColumnWithData<T, K extends keyof T> = TableColumnBase & {
+  dataIndex: K;
+  render?: (value: T[K], record: T, index: number) => React.ReactNode;
+};
+
+/** Column without `dataIndex` — `render` receives `undefined` for the value. */
+export type TableColumnWithoutData<T> = TableColumnBase & {
+  dataIndex?: undefined;
+  render?: (value: undefined, record: T, index: number) => React.ReactNode;
+};
+
+export type TableColumn<T> =
+  | TableColumnWithoutData<T>
+  | { [K in keyof T]: TableColumnWithData<T, K> }[keyof T];
+
+/**
+ * Strips `readonly` so the builder's inferred tuple is directly assignable to
+ * the mutable `TableProps.columns` array. Without this, TS reports TS4104 in
+ * the IDE when a `readonly [...]` tuple meets a mutable `T[]` parameter.
+ */
+type MutableTuple<Cs extends readonly unknown[]> = {
+  -readonly [I in keyof Cs]: Cs[I];
+};
+
+/**
+ * Column builder — required for reliable `render(value, …)` narrowing on inline
+ * arrays. Without it, TS contextual typing on `const cols: TableColumn<T>[] = [...]`
+ * fails under some `tsconfig` strict combos: `value` falls back to `any` and
+ * `dataIndex: "nope"` no longer errors. Calling `defineColumns<T>()([...])`
+ * binds the generic and uses `const` inference so each element narrows by its
+ * `dataIndex` literal.
+ *
+ * The return type drops `readonly` so it slots straight into `TableProps.columns`
+ * (mutable) without TS4104 — preserves narrowing AND keeps the consumer-facing
+ * type shape uniform.
+ *
+ * Usage:
+ *   const columns = defineColumns<Order>()([
+ *     { dataIndex: "amount", key: "amount", title: "Amount",
+ *       render: (value) => fmt(value) }, // value: number
+ *   ]);
+ */
+export function defineColumns<T>() {
+  return <const Cs extends readonly TableColumn<T>[]>(
+    cs: Cs
+  ): MutableTuple<Cs> => cs as unknown as MutableTuple<Cs>;
+}
+
+export type RowKey<T> = keyof T | ((record: T, index: number) => string);
+
+// ---------------------------------------------------------------------------
+// Internal selection checkbox — built directly on base-ui Checkbox primitive
+// because shadcn's `<Checkbox>` wrapper hard-codes its indicator (always a
+// tick), giving indeterminate no distinct visual. Composing the primitive
+// here lets us swap the icon based on `indeterminate`. `components/ui/**` is
+// strictly read-only, so the alternative is to inline it at the call site.
+//
+// MAINTAINER NOTE: the class string below is a hand-copy of
+// `components/ui/checkbox.tsx`. When shadcn `checkbox` is upgraded
+// (`pnpm dlx shadcn@latest add checkbox --overwrite`), eyeball-diff the
+// shadcn `Checkbox` className against this one and resync.
+// ---------------------------------------------------------------------------
+
+type SelectionCheckboxProps = ComponentProps<typeof CheckboxPrimitive.Root>;
+
+function SelectionCheckbox({
+  className,
+  indeterminate,
+  ...rest
+}: SelectionCheckboxProps) {
+  return (
+    <CheckboxPrimitive.Root
+      className={cn(
+        // Disabled visual tokens (Round 7): swap the default
+        // `disabled:opacity-50` for an explicit grey fill + soft border so an
+        // unchecked-disabled checkbox is clearly distinguishable from a normal
+        // unchecked one. `data-checked:*` / `data-indeterminate:*` selectors
+        // sit later in the cascade and still override the fill when the row
+        // is both checked AND disabled (rare but legal).
+        "peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input outline-none transition-colors after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:border-muted-foreground/30 disabled:bg-muted data-checked:border-primary data-indeterminate:border-primary data-checked:bg-primary data-indeterminate:bg-primary data-checked:text-primary-foreground data-indeterminate:text-primary-foreground dark:bg-input/30",
+        className
+      )}
+      data-slot="easy-table-selection-checkbox"
+      indeterminate={indeterminate}
+      {...rest}
+    >
+      {/* base-ui auto-unmounts Indicator while unchecked — exactly what we
+          want. Do NOT add `keepMounted`: the tick SVG would stay in the DOM
+          on unchecked rows and bleed through (visual bug fixed in round 6). */}
+      <CheckboxPrimitive.Indicator
+        className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
+        data-slot="easy-table-selection-indicator"
+      >
+        <HugeiconsIcon
+          aria-hidden
+          data-icon={indeterminate ? "indeterminate" : "checked"}
+          icon={indeterminate ? MinusSignIcon : Tick02Icon}
+          strokeWidth={2}
+        />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Table
+// ---------------------------------------------------------------------------
+
+export interface TableProps<T>
+  extends Omit<React.ComponentProps<"table">, "children"> {
+  /** className on `<tbody>`. */
+  bodyClassName?: ClassValue;
+  /** Caption rendered inside `<caption>`. */
+  caption?: React.ReactNode;
+  /** className on `<caption>`. */
+  captionClassName?: ClassValue;
+  /** Column definitions. */
+  columns: TableColumn<T>[];
+  /**
+   * Data rows. Internally treated as `[]` when `null` / `undefined` are passed,
+   * so `data ?? []` is recommended for SWR / React Query users — and forgetting
+   * the fallback won't crash.
+   */
+  dataSource: T[];
+  /** Uncontrolled initial selected keys. */
+  defaultSelectedRowKeys?: string[];
+  /** className on the empty-state cell. */
+  emptyClassName?: ClassValue;
+  /** Empty-state message rendered when `dataSource` is empty and not loading. @default "No data" */
+  emptyMessage?: React.ReactNode;
+  /**
+   * Per-row props forwarded to the selection-column Checkbox.
+   *
+   * NOTE: `getCheckboxProps` is an explicit exception to AGENTS.md's "no
+   * xxxProps" rule — approved by the user for Antd parity. The returned
+   * `checked` and `onCheckedChange` are always overridden by the Table so
+   * external props can't desync the selection state. `disabled: true` excludes
+   * the row from the header "select all" tally.
+   *
+   * Keep this function pure and non-throwing — it's invoked for every row on
+   * every render. Throwing here unmounts the surrounding tree (error boundary
+   * is the consumer's responsibility, not the Table's).
+   *
+   * Recommended: pass a human-readable `aria-label` here so screen-reader users
+   * hear meaningful text instead of the opaque row key. The Table's default
+   * (`Select row {key}`) only fires when you don't supply one.
+   */
+  getCheckboxProps?: (
+    record: T,
+    index: number
+  ) => Partial<SelectionCheckboxProps>;
+
+  /** className on `<thead>`. */
+  headerClassName?: ClassValue;
+
+  /** When `true`, the body shows a loading message instead of rows/empty state. */
+  loading?: boolean;
+  /** className on the loading-state cell. */
+  loadingClassName?: ClassValue;
+  /** Loading message. @default "Loading…" */
+  loadingMessage?: React.ReactNode;
+
+  /**
+   * Click handler for each `<tr>`. When provided, rows become focusable
+   * (`tabIndex=0`, native `role="row"` preserved) and respond to Enter / Space.
+   * Clicks that originate inside the selection cell do not bubble through.
+   * Interactive elements inside cells (Button, Link) still bubble — call
+   * `event.stopPropagation()` from their own handlers if needed.
+   */
+  onRowClick?: (record: T, index: number) => void;
+  /**
+   * Called when the selection changes. `rows` mirrors the selected records in
+   * `dataSource` order so consumers don't need a second lookup.
+   */
+  onSelectedRowKeysChange?: (keys: string[], rows: T[]) => void;
+
+  /** Per-row className. Function form receives `(record, index)`. */
+  rowClassName?: ClassValue | ((record: T, index: number) => ClassValue);
+  /**
+   * How to derive a stable string key per row. Required — falling back to
+   * `index` silently breaks reordering / pagination, so we surface it.
+   */
+  rowKey: RowKey<T>;
+
+  /** Enable a left-side selection column with checkboxes. */
+  selectable?: boolean;
+  /** Controlled selected row keys. */
+  selectedRowKeys?: string[];
+  /** className applied to the selection column's `th` and every selection `td`. */
+  selectionColumnClassName?: ClassValue;
+  /**
+   * Visually-hidden header text for the selection column. Used as the
+   * accessible name announced before the "Select all" checkbox.
+   * @default "Selection"
+   */
+  selectionColumnLabel?: string;
+}
+
+/**
+ * Diagnostic shape returned alongside the stringified key. `kind` is set when
+ * the raw `rowKey` value would produce a meaningless / corrupted string
+ * (`String(Symbol())` actually throws, `null`/`undefined` both stringify to
+ * `"null"` / `"undefined"` and collide silently).
+ */
+type ResolvedKey = {
+  key: string;
+  diagnostic: "nullish" | "symbol" | null;
+};
+
+function resolveRowKey<T>(
+  record: T,
+  index: number,
+  rowKey: RowKey<T>
+): ResolvedKey {
+  if (typeof rowKey === "function") {
+    return { diagnostic: null, key: rowKey(record, index) };
+  }
+  const raw = record[rowKey];
+  if (raw == null) {
+    return { diagnostic: "nullish", key: String(raw) };
+  }
+  if (typeof raw === "symbol") {
+    // Calling String() on a Symbol coerces it (`"Symbol(foo)"`) without
+    // throwing — but symbol-valued keys still defeat both equality checks and
+    // form submission. Surface them.
+    return { diagnostic: "symbol", key: (raw as symbol).toString() };
+  }
+  return { diagnostic: null, key: String(raw) };
+}
+
+function alignClass(align: TableColumnBase["align"]): string | undefined {
+  if (align === "center") {
+    return "text-center";
+  }
+  if (align === "right") {
+    return "text-right";
+  }
+  return;
+}
+
+function widthStyle(
+  width: TableColumnBase["width"]
+): React.CSSProperties | undefined {
+  if (width === undefined) {
+    return;
+  }
+  return { width };
+}
+
+// Heuristic: a table needs an accessible name. Caption, aria-label, or
+// aria-labelledby all count. Anything truthy passes the audit.
+function hasAccessibleName(
+  caption: React.ReactNode,
+  ariaLabel: string | undefined,
+  ariaLabelledBy: string | undefined
+): boolean {
+  if (ariaLabel || ariaLabelledBy) {
+    return true;
+  }
+  if (caption === undefined || caption === null || caption === false) {
+    return false;
+  }
+  if (typeof caption === "string") {
+    return caption.trim().length > 0;
+  }
+  return true;
+}
+
+export function Table<T>({
+  columns,
+  dataSource,
+  rowKey,
+  loading,
+  loadingMessage = "Loading…",
+  emptyMessage = "No data",
+  caption,
+  rowClassName,
+  onRowClick,
+  selectable,
+  selectedRowKeys,
+  defaultSelectedRowKeys,
+  onSelectedRowKeysChange,
+  getCheckboxProps,
+  selectionColumnClassName,
+  selectionColumnLabel = "Selection",
+  className,
+  headerClassName,
+  bodyClassName,
+  captionClassName,
+  emptyClassName,
+  loadingClassName,
+  ...tableProps
+}: TableProps<T>): ReactElement {
+  // Runtime safety: SWR / React Query often hands `data` back as `undefined`
+  // before the first response. Treat that as empty rather than throwing.
+  const data: T[] = dataSource ?? [];
+
+  const [internalSelected, setInternalSelected] = useState<string[]>(
+    defaultSelectedRowKeys ?? []
+  );
+  const isSelectionControlled = selectedRowKeys !== undefined;
+  const currentSelected = isSelectionControlled
+    ? (selectedRowKeys as string[])
+    : internalSelected;
+
+  // React Compiler is enabled (next.config.ts) — we trust it for memoization
+  // rather than hand-wrapping every derived value in useMemo / useCallback,
+  // which only created false-confidence cache (e.g. `getCheckboxProps` changes
+  // identity on every parent render, busting the rowMeta memo anyway).
+  //
+  // Track diagnostics as primitive flags (not an array) so they're stable for
+  // the dev-warning useEffect's dependency comparison.
+  let sawNullishKey = false;
+  let sawSymbolKey = false;
+  const rowMeta = data.map((record, index) => {
+    const resolved = resolveRowKey(record, index, rowKey);
+    if (resolved.diagnostic === "nullish") {
+      sawNullishKey = true;
+    } else if (resolved.diagnostic === "symbol") {
+      sawSymbolKey = true;
+    }
+    const checkboxProps = getCheckboxProps
+      ? getCheckboxProps(record, index)
+      : {};
+    return {
+      checkboxProps,
+      index,
+      key: resolved.key,
+      record,
+      selected: currentSelected.includes(resolved.key),
+    };
+  });
+
+  // Map for O(1) "is this key still in rowMeta?" lookups in handleToggleAll.
+  // Walks rowMeta once; replaces the previous `Array.prototype.find` loop
+  // which was O(N²) at scale.
+  const metaByKey = new Map(rowMeta.map((m) => [m.key, m]));
+
+  const selectableRows = rowMeta.filter((r) => !r.checkboxProps.disabled);
+  const selectableCount = selectableRows.length;
+  const selectedSelectableCount = selectableRows.filter(
+    (r) => r.selected
+  ).length;
+
+  const allSelected =
+    selectableCount > 0 && selectedSelectableCount === selectableCount;
+  const someSelected =
+    selectedSelectableCount > 0 && selectedSelectableCount < selectableCount;
+
+  // Fingerprint of the currently-duplicated key set — `null` when no dupes.
+  // Lets us re-warn when the offending dataset changes shape, but stay quiet
+  // when the same dupes scroll past.
+  const dupKeyFingerprint = (() => {
+    if (metaByKey.size === data.length) {
+      return null;
+    }
+    const seen = new Set<string>();
+    const dupes = new Set<string>();
+    for (const m of rowMeta) {
+      if (seen.has(m.key)) {
+        dupes.add(m.key);
+      } else {
+        seen.add(m.key);
+      }
+    }
+    return Array.from(dupes).sort().join(" ");
+  })();
+
+  // Fingerprint of duplicate column keys — same pattern.
+  const dupColumnKeyFingerprint = (() => {
+    const seen = new Set<string>();
+    const dupes = new Set<string>();
+    for (const c of columns) {
+      if (seen.has(c.key)) {
+        dupes.add(c.key);
+      } else {
+        seen.add(c.key);
+      }
+    }
+    if (dupes.size === 0) {
+      return null;
+    }
+    return Array.from(dupes).sort().join(" ");
+  })();
+
+  // ---- Dev-only warnings ----
+  // Each warn lives in its own useEffect so the dependency list stays
+  // honest (no over-running, no false silence) and the function complexity
+  // stays low. All are stripped in production by the env guard.
+  const dupKeyWarnedRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production") {
+      return;
+    }
+    if (
+      dupKeyFingerprint !== null &&
+      !dupKeyWarnedRef.current.has(dupKeyFingerprint)
+    ) {
+      dupKeyWarnedRef.current.add(dupKeyFingerprint);
+      console.warn(
+        "[Table] Duplicate row keys detected. Each row must produce a unique key — check your `rowKey` prop."
+      );
+    }
+  }, [dupKeyFingerprint]);
+
+  const dupColKeyWarnedRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production") {
+      return;
+    }
+    if (
+      dupColumnKeyFingerprint !== null &&
+      !dupColKeyWarnedRef.current.has(dupColumnKeyFingerprint)
+    ) {
+      dupColKeyWarnedRef.current.add(dupColumnKeyFingerprint);
+      console.warn(
+        "[Table] Duplicate column keys detected. Each `column.key` must be unique."
+      );
+    }
+  }, [dupColumnKeyFingerprint]);
+
+  const nullishKeyWarnedRef = useRef(false);
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production") {
+      return;
+    }
+    if (!nullishKeyWarnedRef.current && sawNullishKey) {
+      nullishKeyWarnedRef.current = true;
+      console.warn(
+        '[Table] `rowKey` resolved to null or undefined on at least one row, which stringifies to "null" / "undefined" and collides with other rows. Pick a `rowKey` field that is always present.'
+      );
+    }
+  }, [sawNullishKey]);
+
+  const symbolKeyWarnedRef = useRef(false);
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production") {
+      return;
+    }
+    if (!symbolKeyWarnedRef.current && sawSymbolKey) {
+      symbolKeyWarnedRef.current = true;
+      console.warn(
+        "[Table] `rowKey` resolved to a Symbol on at least one row. Symbols don't round-trip through equality checks or form submission — use a string / number identifier."
+      );
+    }
+  }, [sawSymbolKey]);
+
+  const controlledDefaultWarnedRef = useRef(false);
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production") {
+      return;
+    }
+    if (
+      !controlledDefaultWarnedRef.current &&
+      isSelectionControlled &&
+      defaultSelectedRowKeys !== undefined
+    ) {
+      controlledDefaultWarnedRef.current = true;
+      console.warn(
+        "[Table] Both `selectedRowKeys` (controlled) and `defaultSelectedRowKeys` were passed. `defaultSelectedRowKeys` is ignored — drop one of them to silence this warning."
+      );
+    }
+  }, [isSelectionControlled, defaultSelectedRowKeys]);
+
+  // Lock in the controlled / uncontrolled choice from first mount; React's
+  // own input warnings follow the same pattern.
+  const initialControlledRef = useRef(isSelectionControlled);
+  const controlledSwitchWarnedRef = useRef(false);
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production") {
+      return;
+    }
+    if (
+      !controlledSwitchWarnedRef.current &&
+      isSelectionControlled !== initialControlledRef.current
+    ) {
+      controlledSwitchWarnedRef.current = true;
+      const from = initialControlledRef.current ? "controlled" : "uncontrolled";
+      const to = isSelectionControlled ? "controlled" : "uncontrolled";
+      console.warn(
+        `[Table] \`selectedRowKeys\` switched from ${from} to ${to}. Pick one — toggling between the two modes resets the selection state and confuses users.`
+      );
+    }
+  }, [isSelectionControlled]);
+
+  const namelessWarnedRef = useRef(false);
+  const ariaLabel = tableProps["aria-label"];
+  const ariaLabelledBy = tableProps["aria-labelledby"];
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production") {
+      return;
+    }
+    if (
+      !(
+        namelessWarnedRef.current ||
+        hasAccessibleName(caption, ariaLabel, ariaLabelledBy)
+      )
+    ) {
+      namelessWarnedRef.current = true;
+      console.warn(
+        "[Table] No accessible name. Pass `caption`, `aria-label`, or `aria-labelledby` so screen-reader users can identify this table (WCAG 1.3.1)."
+      );
+    }
+  }, [caption, ariaLabel, ariaLabelledBy]);
+
+  const emit = (nextKeys: string[]) => {
+    if (!isSelectionControlled) {
+      setInternalSelected(nextKeys);
+    }
+    if (onSelectedRowKeysChange) {
+      const rows: T[] = [];
+      // Walk data so the emitted rows array stays in source order.
+      const set = new Set(nextKeys);
+      for (let i = 0; i < data.length; i++) {
+        const { key } = resolveRowKey(data[i], i, rowKey);
+        if (set.has(key)) {
+          rows.push(data[i]);
+        }
+      }
+      onSelectedRowKeysChange(nextKeys, rows);
+    }
+  };
+
+  const handleToggleAll = (next: boolean) => {
+    // Preserve any currently-selected keys that point to disabled or
+    // since-removed rows — the header only governs the selectable subset.
+    const preserved = currentSelected.filter((k) => {
+      const meta = metaByKey.get(k);
+      // Row no longer in dataSource: keep it (caller owns lifecycle).
+      if (!meta) {
+        return true;
+      }
+      return Boolean(meta.checkboxProps.disabled);
+    });
+    if (next) {
+      const additions = selectableRows.map((r) => r.key);
+      // Merge while preserving order: dataSource order first, then preserved tail.
+      const seen = new Set<string>();
+      const merged: string[] = [];
+      for (const k of [...additions, ...preserved]) {
+        if (!seen.has(k)) {
+          seen.add(k);
+          merged.push(k);
+        }
+      }
+      emit(merged);
+      return;
+    }
+    emit(preserved);
+  };
+
+  const handleToggleRow = (key: string, next: boolean) => {
+    if (next) {
+      if (currentSelected.includes(key)) {
+        return;
+      }
+      emit([...currentSelected, key]);
+      return;
+    }
+    emit(currentSelected.filter((k) => k !== key));
+  };
+
+  const colSpan = columns.length + (selectable ? 1 : 0);
+
+  const handleRowKeyDown = (
+    event: KeyboardEvent<HTMLTableRowElement>,
+    record: T,
+    index: number
+  ) => {
+    if (!onRowClick) {
+      return;
+    }
+    if (event.key === "Enter" || event.key === " ") {
+      // Space would otherwise scroll the page.
+      event.preventDefault();
+      onRowClick(record, index);
+    }
+  };
+
+  return (
+    <TableRoot
+      aria-busy={loading || undefined}
+      className={cn(className)}
+      data-slot="easy-table"
+      {...tableProps}
+    >
+      {caption && (
+        <TableCaption className={cn(captionClassName)}>{caption}</TableCaption>
+      )}
+      <TableHeader className={cn(headerClassName)}>
+        <TableRow>
+          {selectable && (
+            <TableHead
+              className={cn("w-[1%]", selectionColumnClassName)}
+              data-slot="easy-table-selection-head"
+            >
+              {/* Visually-hidden column name so sighted users still get the
+                  "Select all" affordance and AT users hear a real column
+                  header before the checkbox. */}
+              <span className="sr-only">{selectionColumnLabel}</span>
+              <SelectionCheckbox
+                aria-label="Select all rows"
+                checked={allSelected}
+                disabled={selectableCount === 0}
+                indeterminate={someSelected}
+                onCheckedChange={handleToggleAll}
+              />
+            </TableHead>
+          )}
+          {columns.map((col) => (
+            <TableHead
+              className={cn(
+                alignClass(col.align),
+                col.className,
+                col.headClassName
+              )}
+              key={col.key}
+              style={widthStyle(col.width)}
+            >
+              {col.title}
+            </TableHead>
+          ))}
+        </TableRow>
+      </TableHeader>
+      <TableBody className={cn(bodyClassName)}>
+        {loading && (
+          <TableRow>
+            <TableCell
+              aria-live="polite"
+              className={cn(
+                "h-24 text-center text-muted-foreground",
+                loadingClassName
+              )}
+              colSpan={colSpan}
+              role="status"
+            >
+              {loadingMessage}
+            </TableCell>
+          </TableRow>
+        )}
+        {!loading && data.length === 0 && (
+          <TableRow>
+            <TableCell
+              aria-live="polite"
+              className={cn(
+                "h-24 text-center text-muted-foreground",
+                emptyClassName
+              )}
+              colSpan={colSpan}
+              role="status"
+            >
+              {emptyMessage}
+            </TableCell>
+          </TableRow>
+        )}
+        {!loading &&
+          rowMeta.map(({ checkboxProps, index, key, record, selected }) => {
+            const rowCls =
+              typeof rowClassName === "function"
+                ? rowClassName(record, index)
+                : rowClassName;
+            const interactive = Boolean(onRowClick);
+            // External `checked` / `onCheckedChange` are intentionally
+            // discarded — Table owns selection state. `aria-label` is left
+            // intact so consumers can override the opaque default below.
+            const {
+              checked: _ignoredChecked,
+              onCheckedChange: _ignoredOnCheckedChange,
+              ...passthroughCheckboxProps
+            } = checkboxProps;
+            return (
+              <TableRow
+                className={cn(
+                  // `outline-offset:-2px` keeps the focus ring inside the row
+                  // so it isn't clipped by a parent `rounded-md border`
+                  // wrapper (the recommended demo pattern).
+                  interactive &&
+                    "cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring focus-visible:[outline-offset:-2px]",
+                  rowCls
+                )}
+                data-state={selected ? "selected" : undefined}
+                key={key}
+                onClick={
+                  interactive ? () => onRowClick?.(record, index) : undefined
+                }
+                onKeyDown={
+                  interactive
+                    ? (e) => handleRowKeyDown(e, record, index)
+                    : undefined
+                }
+                // Preserve the implicit `role="row"` of <tr> per W3C ARIA APG's
+                // grid pattern — overriding to `role="button"` would strip the
+                // table semantics. Keyboard activation is provided via
+                // `tabIndex` + onKeyDown(Enter/Space).
+                tabIndex={interactive ? 0 : undefined}
+              >
+                {selectable && (
+                  <TableCell
+                    className={cn(selectionColumnClassName)}
+                    data-slot="easy-table-selection-cell"
+                    // Clicks (and key presses) inside the selection cell must
+                    // not bubble up to the row's onRowClick handler.
+                    onClick={(e: MouseEvent<HTMLTableCellElement>) =>
+                      e.stopPropagation()
+                    }
+                    onKeyDown={(e: KeyboardEvent<HTMLTableCellElement>) =>
+                      e.stopPropagation()
+                    }
+                  >
+                    <SelectionCheckbox
+                      aria-label={`Select row ${key}`}
+                      {...passthroughCheckboxProps}
+                      checked={selected}
+                      onCheckedChange={(next) => handleToggleRow(key, next)}
+                    />
+                  </TableCell>
+                )}
+                {columns.map((col) => {
+                  const value =
+                    col.dataIndex === undefined
+                      ? undefined
+                      : record[col.dataIndex];
+                  const content = col.render
+                    ? // The discriminated union narrows correctly externally,
+                      // but inside the generic body the two render signatures
+                      // can't be reconciled without an unsafe cast.
+                      // biome-ignore lint/suspicious/noExplicitAny: see comment above
+                      (col.render as any)(value, record, index)
+                    : (value as React.ReactNode);
+                  return (
+                    <TableCell
+                      className={cn(
+                        alignClass(col.align),
+                        col.className,
+                        col.cellClassName
+                      )}
+                      key={col.key}
+                      style={widthStyle(col.width)}
+                    >
+                      {content}
+                    </TableCell>
+                  );
+                })}
+              </TableRow>
+            );
+          })}
+      </TableBody>
+    </TableRoot>
+  );
+}
+
+export default Table;

--- a/scripts/genarate-example-entry.mjs
+++ b/scripts/genarate-example-entry.mjs
@@ -15,7 +15,7 @@ for (const fileName of exampleFileNames) {
     contentStr += `
   "${name}": {
     component: React.lazy(() => import("./${name}")),
-    codeString: \`${codeContent}\`
+    codeString: ${JSON.stringify(codeContent)}
   },
 `;
   }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,11 +1,18 @@
+import path from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(import.meta.dirname, "."),
+    },
+  },
   test: {
     environment: "jsdom",
     globals: true,
     include: ["registry/**/*.test.{ts,tsx}"],
+    setupFiles: ["./vitest.setup.ts"],
   },
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,6 @@
+// jsdom lacks PointerEvent; base-ui Checkbox dispatches one on click.
+// A MouseEvent-shaped polyfill is enough for the bubbling click forwarder.
+if (typeof globalThis.PointerEvent === "undefined") {
+  // biome-ignore lint/suspicious/noExplicitAny: minimal jsdom shim
+  (globalThis as any).PointerEvent = class PointerEvent extends MouseEvent {};
+}


### PR DESCRIPTION
Compose-layer Table over shadcn primitives with Antd-style flat API (columns + dataSource + rowKey). Supports column.render (data-layer hook), controlled/uncontrolled selection with indeterminate dash icon, onRowClick keeping role="row" semantics, getCheckboxProps (Antd parity exception), and seven dev-only warnings (dup row/column keys, nullish/symbol keys, controlled+default, controlled switch, missing a11y name). 81 unit tests, coverage 98/100/95/98.