### PR TITLE
docs: surface new components + fix(command-modal): type errors & defect-audit hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ See the [installation guide](https://easy-shadcn.vercel.app/docs/installation) f
 | **Modal** | Imperative `alert` / `confirm` helpers + a composable Modal on top of shadcn Dialog | `@easy-shadcn/modal` |
 | **Calendar** | Native month/year dropdowns into a three-view button-grid navigation | `@easy-shadcn/calendar` |
 | **Date Picker** | Single / multiple / range / inline-input variants under one component | `@easy-shadcn/date-picker` |
+| **Accordion** | The repeated `<AccordionItem><AccordionTrigger>…<AccordionContent>…` triple into an `items={…}` array of `{ value, trigger, content }` | `@easy-shadcn/accordion` |
+| **Breadcrumb** | Hand-nested `<BreadcrumbList>` / `<BreadcrumbItem>` / `<BreadcrumbLink>` / `<BreadcrumbSeparator>` markup into an `items={…}` array | `@easy-shadcn/breadcrumb` |
+| **Tooltip** | The `<TooltipProvider>` / `<Tooltip>` / `<TooltipTrigger>` / `<TooltipContent>` nest into one `children` trigger plus a `content` prop | `@easy-shadcn/tooltip` |
+| **Radio Group** | Hand-wired `<RadioGroupItem>` controls plus their `<label>` / description markup into an `items={…}` array of `{ value, label, description }` | `@easy-shadcn/radio-group` |
 
 ## Design Philosophy
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -46,6 +46,10 @@ pnpm dlx shadcn@latest add @easy-shadcn/card
 | **Modal** | 命令式 `alert` / `confirm` 助手 + 基于 shadcn Dialog 的组合式 Modal | `@easy-shadcn/modal` |
 | **Calendar** | 原生月/年下拉 → 三视图按钮网格切换 | `@easy-shadcn/calendar` |
 | **Date Picker** | 单选 / 多选 / 范围 / inline-input 多形态合一 | `@easy-shadcn/date-picker` |
+| **Accordion** | 每行重复的 `<AccordionItem><AccordionTrigger>…<AccordionContent>…` 三件套 → 一个 `items={…}` 数组（`{ value, trigger, content }`） | `@easy-shadcn/accordion` |
+| **Breadcrumb** | 手写嵌套的 `<BreadcrumbList>` / `<BreadcrumbItem>` / `<BreadcrumbLink>` / `<BreadcrumbSeparator>` → 一个 `items={…}` 数组 | `@easy-shadcn/breadcrumb` |
+| **Tooltip** | `<TooltipProvider>` / `<Tooltip>` / `<TooltipTrigger>` / `<TooltipContent>` 四层嵌套 → 一个 `children` 触发元素 + 一个 `content` prop | `@easy-shadcn/tooltip` |
+| **Radio Group** | 逐个手接的 `<RadioGroupItem>` 控件 + `<label>` / 描述结构 → 一个 `items={…}` 数组（`{ value, label, description }`） | `@easy-shadcn/radio-group` |
 
 ## 设计理念
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -104,6 +104,31 @@ const components = [
     blurb: "Single, multiple, range, inline-input — one component.",
     install: "@easy-shadcn/date-picker",
   },
+  {
+    no: "07",
+    name: "Accordion",
+    blurb: "Items array in. Expandable panels out. No nested triple per row.",
+    install: "@easy-shadcn/accordion",
+  },
+  {
+    no: "08",
+    name: "Breadcrumb",
+    blurb: "Trail of items in. Auto current page and collapsing ellipsis out.",
+    install: "@easy-shadcn/breadcrumb",
+  },
+  {
+    no: "09",
+    name: "Tooltip",
+    blurb: "Wrap an element, pass content. Its own provider — zero setup.",
+    install: "@easy-shadcn/tooltip",
+  },
+  {
+    no: "10",
+    name: "Radio Group",
+    blurb:
+      "Options array in. Wired-up radio rows out. Labels and a11y included.",
+    install: "@easy-shadcn/radio-group",
+  },
 ];
 
 const principles = [
@@ -406,7 +431,7 @@ function Ticker() {
 
 function ByTheNumbers() {
   const stats = [
-    { value: "06", label: "components", note: "and growing" },
+    { value: "10", label: "components", note: "and growing" },
     { value: "80/20", label: "by design", note: "no slot abuse" },
     { value: "01", label: "line install", note: "shadcn CLI" },
     { value: "100%", label: "yours", note: "MIT, copy & own" },
@@ -676,7 +701,7 @@ function ComponentsIndex() {
               ✦ Section III · The Catalogue
             </p>
             <h2 className="mt-4 font-display font-light text-[clamp(2.6rem,6vw,5rem)] leading-[0.95] tracking-[-0.03em]">
-              Six pieces.
+              Ten pieces.
               <br />
               <em className="text-[var(--accent)] italic">Each earned its</em>
               {"  "}

--- a/packages/command-modal/src/actions.tsx
+++ b/packages/command-modal/src/actions.tsx
@@ -20,6 +20,7 @@ import type {
   CommandModalArgs,
   CommandModalCallbacks,
   CreateModalComponent,
+  ModalInnerProps,
 } from "./type";
 import { useModal } from "./useModal";
 
@@ -96,6 +97,13 @@ export function showWithDispatch(
     register(modalId, modal);
   }
   resolveActions(dispatch).showModal(modalId, args);
+  // Re-showing dismisses any hide() still awaiting its close: settle that stale
+  // hide promise with `undefined` and drop it. Otherwise createModalPromise's
+  // `if (!callbacksStore[modalId])` guard would let the next hide() reuse the
+  // interrupted cycle's promise, cross-settling two close cycles (and leaking
+  // the entry until a later teardown). Symmetric with hideWithDispatch settling
+  // the pending show below.
+  settleAndDelete(hideModalCallbacks, modalId);
   return createModalPromise(modalCallbacks, modalId);
 }
 
@@ -106,6 +114,12 @@ export function hideWithDispatch(
   const modalId = getModalId(modal);
   resolveActions(dispatch).hideModal(modalId);
   settleAndDelete(modalCallbacks, modalId);
+  // Settle any prior hide() still pending from an earlier, not-yet-completed
+  // close cycle before minting this hide's promise. Without this, a second
+  // hide() on a reopened (keepMounted) modal would reuse the first cycle's
+  // promise (createModalPromise reuses an existing entry) and the first
+  // awaiter would receive THIS cycle's resolveHide value.
+  settleAndDelete(hideModalCallbacks, modalId);
   return createModalPromise(hideModalCallbacks, modalId);
 }
 
@@ -133,15 +147,15 @@ export function removeWithDispatch(
   // roundtrip because the component is still there).
 }
 
-export function show<T, C, P extends Partial<CommandModalArgs<React.FC<C>>>>(
-  modal: CreateModalComponent<C>,
-  args?: P
+// biome-ignore lint/suspicious/noExplicitAny: C is constrained to any modal component; its concrete props are recovered via ModalInnerProps<C> at each call site.
+export function show<T, C extends CreateModalComponent<any>>(
+  modal: C,
+  args?: Partial<ModalInnerProps<C>>
 ): Promise<T>;
 export function show<T>(
   modal: string,
   args?: Record<string, unknown>
 ): Promise<T>;
-export function show<T, P>(modal: string, args: P): Promise<T>;
 
 /**
  * Show a modal and return a promise tied to its lifecycle.
@@ -163,7 +177,11 @@ export function show<T, P>(modal: string, args: P): Promise<T>;
  * @returns A promise that settles as described above.
  */
 export function show(
-  modal: React.FC | string,
+  // The implementation signature must be a supertype of every overload above.
+  // `CreateModalComponent<C>` carries a required `id`, so it is not assignable
+  // to the bare `React.FC` (= `FC<{}>`); the permissive `React.FC<any>` is.
+  // biome-ignore lint/suspicious/noExplicitAny: see comment above — supertype of all show() overloads.
+  modal: React.FC<any> | string,
   args?: CommandModalArgs<React.FC>
 ) {
   return showWithDispatch(modal, args, null);
@@ -295,11 +313,11 @@ export const create = <P extends object>(Comp: React.ComponentType<P>) => {
 };
 
 // All registered modals will be rendered in modal placeholder
-// biome-ignore lint/suspicious/noExplicitAny: Required for generic component registration - CommandModalArgs<T> extracts actual props
+// biome-ignore lint/suspicious/noExplicitAny: Required for generic component registration - ModalInnerProps<T> extracts the actual props.
 export const register = <T extends CreateModalComponent<any>>(
   id: string,
   comp: T,
-  props?: Partial<CommandModalArgs<T>>
+  props?: Partial<ModalInnerProps<T>>
 ): void => {
   if (MODAL_REGISTRY[id]) {
     MODAL_REGISTRY[id].props = props;

--- a/packages/command-modal/src/context.tsx
+++ b/packages/command-modal/src/context.tsx
@@ -236,26 +236,43 @@ export const useCommandModalDispatch =
 const CommandModalPlaceholder: React.FC = () => {
   const modals = useContext(CommandModalContext);
 
-  // Memoize expensive filtering and mapping operations
-  const toRender = useMemo(() => {
-    const visibleModalIds = Object.keys(modals).filter((id) => !!modals[id]);
+  // Derive synchronously from live module state on every render. No useMemo:
+  // the result depends on MODAL_REGISTRY / ALREADY_MOUNTED, which mutate
+  // (register(), <ModalDef>) without changing `modals`, so a memo keyed on
+  // [modals] could serve a stale list and silently fail to mount a modal that
+  // was registered after its id entered the store. The filter/map is cheap
+  // relative to the modal subtrees it gates.
+  const visibleModalIds = Object.keys(modals).filter((id) => !!modals[id]);
+  const unresolvedIds: string[] = [];
+  const toRender = visibleModalIds
+    .filter((id) => {
+      if (!(MODAL_REGISTRY[id] || ALREADY_MOUNTED[id])) {
+        unresolvedIds.push(id);
+        return false; // Skip this modal but continue processing others
+      }
+      return MODAL_REGISTRY[id]; // Only render registered modals (JSX-declared modals render themselves)
+    })
+    .map((id) => ({
+      id,
+      ...MODAL_REGISTRY[id],
+    }));
 
-    // Validate and filter modals, warning about invalid ones without interrupting others
-    return visibleModalIds
-      .filter((id) => {
-        if (!(MODAL_REGISTRY[id] || ALREADY_MOUNTED[id])) {
-          console.warn(
-            `No modal found for id: ${id}. Please check the id or if it is registered or declared via JSX.`
-          );
-          return false; // Skip this modal but continue processing others
-        }
-        return MODAL_REGISTRY[id]; // Only render registered modals (JSX-declared modals render themselves)
-      })
-      .map((id) => ({
-        id,
-        ...MODAL_REGISTRY[id],
-      }));
-  }, [modals]);
+  // Emit the "no modal found" diagnostic from a commit-phase effect, never from
+  // the render body: render must be side-effect-free, since React may run it
+  // twice (StrictMode) or discard it (concurrent rendering), which would double-
+  // or phantom-log. Keying on the joined id list fires the warning once per
+  // committed set of unresolved ids.
+  const unresolvedKey = unresolvedIds.join(",");
+  useEffect(() => {
+    if (!unresolvedKey) {
+      return;
+    }
+    for (const id of unresolvedKey.split(",")) {
+      console.warn(
+        `No modal found for id: ${id}. Please check the id or if it is registered or declared via JSX.`
+      );
+    }
+  }, [unresolvedKey]);
 
   return (
     <>

--- a/packages/command-modal/src/holders.tsx
+++ b/packages/command-modal/src/holders.tsx
@@ -116,6 +116,15 @@ export function ModalHolder<T>({
   useLayoutEffect(() => {
     handler.show = showCallback;
     handler.hide = hideCallback;
+    // On unmount, swap in inert no-ops. The holder owns an auto-generated id
+    // that is torn down by the unmount effect below; a retained reference
+    // calling `handler.show()` afterwards would resurrect orphan reducer +
+    // promise state for a dead id with nothing left to clean it up. Returning a
+    // settled promise keeps any post-unmount awaiter from hanging.
+    return () => {
+      handler.show = () => Promise.resolve(undefined);
+      handler.hide = () => Promise.resolve(undefined);
+    };
   }, [handler, showCallback, hideCallback]);
 
   // ModalHolder owns an auto-generated id that has no lifetime beyond the

--- a/packages/command-modal/src/index.ts
+++ b/packages/command-modal/src/index.ts
@@ -3,9 +3,12 @@
  * Copyright (c) 2021 eBay Inc.
  * License: MIT
  */
-// Core API
+// Public surface: runtime API + types, grouped by source module and sorted to
+// satisfy organizeImports. Runtime: create/hide/register/remove/show/unregister
+// (actions), Provider + contexts (context), ModalDef (holders), the hooks
+// (useModal). Types follow each module.
 export { create, hide, register, remove, show, unregister } from "./actions";
-// Context
+export type { CommandModalProviderProps } from "./context";
 export {
   CommandModalContext,
   CommandModalDispatchContext,
@@ -13,21 +16,23 @@ export {
   reducer,
   useCommandModalDispatch,
 } from "./context";
-
-// Types
+export type { ModalHolderActions } from "./holders";
+export { ModalDef } from "./holders";
 export type {
   CommandModalConfig,
   CommandModalHandler,
+  CommandModalHocProps,
+  CreateModalComponent,
+  ModalInnerProps,
   ModalPropsAdapter,
   ShadCNModalProps,
 } from "./type";
-
-// Hooks
 export { createModalProps, useModal, useModalHolder } from "./useModal";
 
 // Default export
 import { create, hide, register, remove, show, unregister } from "./actions";
 import { CommandModalContext, Provider, reducer } from "./context";
+import { ModalDef } from "./holders";
 import { createModalProps, useModal, useModalHolder } from "./useModal";
 
 const CommandModal = {
@@ -38,6 +43,7 @@ const CommandModal = {
   show,
   unregister,
   CommandModalContext,
+  ModalDef,
   Provider,
   reducer,
   createModalProps,

--- a/packages/command-modal/src/type.ts
+++ b/packages/command-modal/src/type.ts
@@ -29,8 +29,8 @@ export interface CommandModalAction {
 }
 export interface CommandModalCallbacks {
   [modalId: string]: {
-    resolve: (args: unknown) => void;
-    reject: (args: unknown) => void;
+    resolve: (args?: unknown) => void;
+    reject: (args?: unknown) => void;
     promise: Promise<unknown>;
   };
 }
@@ -136,8 +136,11 @@ export interface CommandModalHocProps {
   keepMounted?: boolean;
 }
 
+// The inner component's props (`T`) arrive at runtime via `show(id, args)`, not
+// at JSX-mount time. Anything passed where the HOC is mounted (`<Modal id=… />`)
+// only acts as a default, so `T` is partial there — `id` is the sole required prop.
 export type CreateModalComponent<T = object> = React.FC<
-  T & CommandModalHocProps
+  Partial<T> & CommandModalHocProps
 >;
 
 export type CommandModalArgs<T> = T extends
@@ -145,3 +148,18 @@ export type CommandModalArgs<T> = T extends
   | React.JSXElementConstructor<unknown>
   ? React.ComponentProps<T>
   : Record<string, unknown>;
+
+/**
+ * The props a modal component accepts at `show()` / `register()` /
+ * `useModal()` time: its own props minus the HOC-reserved keys
+ * (`id` / `defaultVisible` / `keepMounted`), which the system injects.
+ *
+ * Unlike {@link CommandModalArgs} — whose conditional collapses to
+ * `Record<string, unknown>` for any `React.FC` and therefore type-checks
+ * nothing — this derives directly from the component, so a typed modal's
+ * args are actually validated.
+ */
+export type ModalInnerProps<
+  // biome-ignore lint/suspicious/noExplicitAny: must accept any modal component (whose props carry a required `id`), matching CreateModalComponent<any>.
+  C extends React.ComponentType<any>,
+> = Omit<React.ComponentProps<C>, keyof CommandModalHocProps>;

--- a/packages/command-modal/src/useModal.tsx
+++ b/packages/command-modal/src/useModal.tsx
@@ -24,9 +24,9 @@ import {
 } from "./context";
 import { ModalHolder, type ModalHolderActions } from "./holders";
 import type {
-  CommandModalArgs,
   CommandModalHandler,
   CreateModalComponent,
+  ModalInnerProps,
   ShadCNModalProps,
 } from "./type";
 
@@ -36,11 +36,12 @@ export function useModal(
 ): CommandModalHandler & {
   modalProps: ShadCNModalProps;
 };
-export function useModal<C, P extends Partial<CommandModalArgs<React.FC<C>>>>(
-  modal: React.FC<C>,
-  args?: P
+// biome-ignore lint/suspicious/noExplicitAny: C is any modal component; its concrete props are recovered via ModalInnerProps<C>.
+export function useModal<C extends React.FC<any>>(
+  modal: C,
+  args?: Partial<ModalInnerProps<C>>
 ): Omit<CommandModalHandler, "show"> & {
-  show: (args?: P) => Promise<unknown>;
+  show: (args?: Partial<ModalInnerProps<C>>) => Promise<unknown>;
 } & {
   modalProps: ShadCNModalProps;
 };

--- a/packages/command-modal/test/hoc-args-filter.test.tsx
+++ b/packages/command-modal/test/hoc-args-filter.test.tsx
@@ -75,6 +75,7 @@ describe("create() HOC args reserved-key filtering (C8)", () => {
     const TestModal = create(Inner);
 
     const Consumer = () => {
+      // @ts-expect-error `id` is HOC-reserved and is now rejected in args by the type system; this asserts the HOC still strips it at runtime for untyped/JS callers.
       const modal = useModal(TestModal, {
         id: "hijacked-id",
         value: "ok",

--- a/packages/command-modal/test/holder-cleanup.test.tsx
+++ b/packages/command-modal/test/holder-cleanup.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
 import { describe, expect, it } from "vitest";
 import { create } from "../src/actions";
 import {
@@ -7,6 +8,7 @@ import {
   modalCallbacks,
 } from "../src/constants";
 import { __getDispatchStackSize, Provider } from "../src/context";
+import type { ModalHolderActions } from "../src/holders";
 import { useModal, useModalHolder } from "../src/useModal";
 
 /**
@@ -177,5 +179,56 @@ describe("ModalHolder cleanup on unmount", () => {
     expect(Object.keys(hideModalCallbacks).length).toBe(0);
     expect(Object.keys(ALREADY_MOUNTED).length).toBe(baselineAlready);
     expect(__getDispatchStackSize()).toBe(0);
+  });
+
+  it("installs inert no-ops on unmount so a retained handler cannot resurrect state (C5)", async () => {
+    // The holder owns an auto-generated id torn down on unmount. If the
+    // installed handler.show stayed live, a retained reference calling it after
+    // unmount would dispatch to the still-mounted Provider and re-create an
+    // orphan callback entry with nothing left to clean it up.
+    let captured = null as ModalHolderActions | null;
+
+    const HolderWrapper = () => {
+      const [handler, Holder] = useModalHolder(TestModal);
+      captured = handler;
+      return <Holder />;
+    };
+
+    const Parent = () => {
+      const [mounted, setMounted] = useState(true);
+      return (
+        <>
+          <button
+            data-testid="unmount-holder"
+            onClick={() => setMounted(false)}
+            type="button"
+          >
+            unmount
+          </button>
+          {mounted && <HolderWrapper />}
+        </>
+      );
+    };
+
+    render(
+      <Provider>
+        <Parent />
+      </Provider>
+    );
+
+    // Unmount only the holder; the Provider (and its dispatch) stays mounted —
+    // this is exactly the condition under which a live callback could leak.
+    act(() => {
+      fireEvent.click(screen.getByTestId("unmount-holder"));
+    });
+
+    const callbacksAfterUnmount = Object.keys(modalCallbacks).length;
+
+    // Post-unmount show()/hide() must be inert: resolve immediately, add no entry.
+    const showResult = await captured?.show();
+    expect(showResult).toBeUndefined();
+    const hideResult = await captured?.hide();
+    expect(hideResult).toBeUndefined();
+    expect(Object.keys(modalCallbacks).length).toBe(callbacksAfterUnmount);
   });
 });

--- a/packages/command-modal/test/holder-render-purity.test.tsx
+++ b/packages/command-modal/test/holder-render-purity.test.tsx
@@ -41,7 +41,12 @@ describe("ModalHolder render purity (C4)", () => {
   });
 
   it("sets up a working show() on mount and the modal renders after invocation", async () => {
-    let capturedHandler: ModalHolderActions | null = null;
+    // `null as …` keeps the flow-narrowed type as the full union. A bare
+    // `: ModalHolderActions | null = null` narrows to `null` at the reads below
+    // (the assignment happens only inside the render callback, invisible to the
+    // outer control flow), which makes `capturedHandler?.show` resolve its
+    // non-null branch to `never`.
+    let capturedHandler = null as ModalHolderActions | null;
 
     const Parent = () => {
       const [handler, ModalSlot] = useModalHolder(TestModal);

--- a/packages/command-modal/test/integration.test.tsx
+++ b/packages/command-modal/test/integration.test.tsx
@@ -400,7 +400,10 @@ describe("Integration Tests", () => {
         expect(modal).toHaveAttribute("data-visible", "true");
       });
 
-      const firstMountCount = mountCount;
+      // Capture the live DOM node so we can prove keepMounted preserves it
+      // across the hide -> show cycle. A full remount yields a NEW node; a
+      // re-render keeps the same one.
+      const nodeAfterFirstShow = screen.getByTestId("keep-mounted-modal");
 
       // Hide modal (should stay in DOM due to keepMounted)
       act(() => {
@@ -423,8 +426,9 @@ describe("Integration Tests", () => {
         expect(modal).toHaveAttribute("data-visible", "true");
       });
 
-      // Mount count should not increase significantly
-      // (some re-renders are expected, but not full remounts)
+      // keepMounted's core invariant: the element was never unmounted/remounted
+      // — it is the very same DOM node throughout the hide -> show cycle.
+      expect(screen.getByTestId("keep-mounted-modal")).toBe(nodeAfterFirstShow);
     });
 
     it("should remove modal from DOM when keepMounted is false", async () => {
@@ -512,7 +516,7 @@ describe("Integration Tests", () => {
           }
           return (
             <div data-testid="args-modal">
-              <span data-testid="title">{title || modal.args?.title}</span>
+              <span data-testid="title">{title || (modal.args?.title as string)}</span>
               <span data-testid="count">{count ?? modal.args?.count}</span>
             </div>
           );
@@ -543,7 +547,7 @@ describe("Integration Tests", () => {
         }
         return (
           <div data-testid="update-args-modal">
-            {value || modal.args?.value}
+            {value || (modal.args?.value as string)}
           </div>
         );
       });

--- a/packages/command-modal/test/promise-settlement.test.tsx
+++ b/packages/command-modal/test/promise-settlement.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { create, hide, remove, show, unregister } from "../src/actions";
+import { hideModalCallbacks } from "../src/constants";
 import { Provider } from "../src/context";
 import { ModalDef } from "../src/holders";
 import { useModal } from "../src/useModal";
@@ -229,5 +230,57 @@ describe("unregister() / ModalDef unmount also settles outstanding promises", ()
     const outcome = await observeSettlement(hidePromise);
     expect(outcome.settled).toBe(true);
     expect(outcome.value).toBeUndefined();
+  });
+});
+
+/**
+ * Regression: a hide promise belongs to exactly ONE close cycle.
+ *
+ * Before the fix, neither show() nor hide() settled a still-pending
+ * hideModalCallbacks entry, so re-opening a keepMounted modal and closing it
+ * again made the second hide() reuse the first cycle's promise — the first
+ * awaiter then received the SECOND cycle's resolveHide value.
+ */
+describe("cross-cycle hide() promise isolation", () => {
+  it("re-show + second hide() yields a fresh hide promise; the first hide is dismissed with undefined", async () => {
+    render(
+      <Provider>
+        <TestModal id="cross-cycle" keepMounted />
+      </Provider>
+    );
+
+    // Open, then close (hide #1) before its resolveHide fires.
+    let hide1!: Promise<unknown>;
+    act(() => {
+      show("cross-cycle");
+    });
+    act(() => {
+      hide1 = hide("cross-cycle");
+    });
+
+    // Reopen, then close again (hide #2).
+    let hide2!: Promise<unknown>;
+    act(() => {
+      show("cross-cycle");
+    });
+    act(() => {
+      hide2 = hide("cross-cycle");
+    });
+
+    // Each close cycle owns its own promise — the second hide must not reuse
+    // the first cycle's deferred.
+    expect(hide1).not.toBe(hide2);
+
+    // The reopen already settled hide #1 as a dismissal.
+    const firstOutcome = await observeSettlement(hide1);
+    expect(firstOutcome.settled).toBe(true);
+    expect(firstOutcome.value).toBeUndefined();
+
+    // Only the current cycle's resolveHide value reaches hide #2.
+    act(() => {
+      hideModalCallbacks["cross-cycle"]?.resolve("second-close");
+    });
+    const secondOutcome = await observeSettlement(hide2);
+    expect(secondOutcome.value).toBe("second-close");
   });
 });

--- a/packages/command-modal/test/useModal.test.tsx
+++ b/packages/command-modal/test/useModal.test.tsx
@@ -96,7 +96,9 @@ describe("useModal", () => {
         if (!modal.visible) {
           return null;
         }
-        return <div data-testid="modal">{message || modal.args?.message}</div>;
+        return (
+          <div data-testid="modal">{message || (modal.args?.message as string)}</div>
+        );
       });
 
       const ControlComponent = () => {


### PR DESCRIPTION
Two related pieces of work, on one branch as two focused commits.

## 1. Docs — surface the four new compose components
README (EN + zh-CN) and the landing page (`app/page.tsx`) only listed 6 components. Added **Accordion, Breadcrumb, Tooltip, Radio Group**:
- README tables: 4 new rows describing what each collapses (grounded in the real source).
- Landing page: 4 `components[]` entries, by-the-numbers `06 → 10`, catalogue heading `Six pieces. → Ten pieces.`
- Verified every `name → doc-slug` link resolves to an existing `content/docs/components/*.mdx`.

## 2. command-modal — strict-type errors + defect audit

### Strict tsc errors (13 → 0)
`tsc --noEmit` surfaced 13 errors in `command-modal/test/**`. Classified test-vs-code:
- **code** — `CreateModalComponent<T>` required inner props at JSX mount, but they arrive via `show(id, args)` → `Partial<T>` (`id` stays required).
- **code** — `CommandModalCallbacks.resolve/reject` made optional-arg, matching the real deferred resolvers and `CommandModalHandler.resolve`.
- **code** — `show()` impl signature widened to `React.FC<any>` to remain a supertype of all overloads.
- **test** — cast `unknown` reads from the untyped `modal.args` bag; fixed a closure-captured `let` that TS narrowed to `never`.

### Defect audit (adversarial multi-agent review → 19 confirmed)
**Fixed in this PR:**
- 🔴 **Promise settlement** — a `hide()` promise now belongs to exactly one close cycle. `show()`/`hide()` settle any stale `hideModalCallbacks` entry first, so reopening a `keepMounted` modal no longer cross-settles two hide cycles (wrong resolved value) or leaks the entry.
- 🔴 **Type erasure** — `CommandModalArgs<FC>` collapsed to `Record<string, unknown>`, erasing **all** `show`/`register`/`useModal` arg checking. Replaced with `ModalInnerProps<C>`; dropped the redundant `show(string, P)` overload that let primitives through.
- 🟡 **Render purity** — `CommandModalPlaceholder` derives its list from live module state (no stale `[modals]` memo) and warns from an effect, not the render body.
- 🟡 **Lifecycle leak** — `ModalHolder` installs inert no-ops on unmount so a retained handler can't resurrect orphan state.
- 🟡 **Public API** — export `ModalDef` and the types consumers need (`CreateModalComponent`, `ModalInnerProps`, `ModalHolderActions`, `CommandModalProviderProps`, `CommandModalHocProps`).
- 🟡 **Test coverage** — the `keepMounted` "no remount" test asserted nothing (`firstMountCount` was dead); now asserts DOM-node identity. Added regression tests for cross-cycle hide isolation and the post-unmount handler no-op.

**Documented follow-ups (intentionally NOT in this PR — they need a focused, riskier change to hardened core):**
- 🔴 Cross-Provider promise scoping: `modalCallbacks` is keyed by id only, so the same id live in 2+ Providers cross-settles. The correct fix redesigns store ownership (per-Provider stores while keeping the top-level API working) and warrants its own PR.
- 🟡 `hide()` on a never-shown modal creates a promise that hangs until teardown (needs store-state threading through the dispatch-only path).
- 🟡 Render-phase `dispatchStack` push can leak on an aborted Provider render (changing it overrides a deliberate, documented design; exceptional trigger).

### Verification
- `tsc --noEmit` (whole repo): **0 errors**
- command-modal: **152 tests pass** (+2 regression), coverage ≥ thresholds (lines 99 / funcs 95.5 / branches 100 / stmts 99)
- package build (CJS + ESM + d.ts): OK
- dependent `registry/ui/modal` tests: 12 pass
- lint (ultracite): all `src` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)