### PR TITLE
command-modal: type-safety + first-class antd (factory, resolve types, Base UI hook)

### DIFF
--- a/.changeset/command-modal-type-safety.md
+++ b/.changeset/command-modal-type-safety.md
@@ -1,0 +1,40 @@
+---
+"@easy-shadcn/command-modal": minor
+---
+
+Type-safe adapters, first-class antd, and a leak fix in the default shadcn adapter.
+
+**New**
+
+- `createCommandModal(adapter)` factory returns a config-bound
+  `{ Provider, useModal }` whose `modalProps` is statically typed as the
+  adapter's return type — antd / any-library consumers now get type-safe
+  `modalProps` with no casts. shadcn stays the zero-config default at the
+  package root. The factory's `useModal` is a type-only reskin of the same
+  runtime hook, so it never re-runs the adapter or breaks memoization.
+- Official **Ant Design v6** adapter: `antdModalProps` (and a hand-written,
+  `antd`-import-free `AntdModalProps` type) exported from
+  `@easy-shadcn/command-modal/antd`. The core entry stays zero-dependency.
+- `create<Props, Result>` now carries the modal's resolve type. `show(Comp, args)`
+  infers both the args and `Promise<Result>` with no explicit type argument — the
+  old `show<T>(Comp)` form (which degraded to the string overload) is no longer
+  needed.
+
+**Fixes**
+
+- `<Dialog {...modal.modalProps}>` no longer leaks. The default shadcn adapter
+  emitted `afterClose` — an antd concept Base UI's Dialog doesn't read — so the
+  modal was never removed after closing, leaking a reducer entry and a mounted
+  HOC per show. It now emits Base UI's real `onOpenChangeComplete` hook, guarded
+  on close, so the modal is removed once its close animation finishes.
+- Removed the dead `CommandModalArgs` type (it collapsed to
+  `Record<string, unknown>` for any `React.FC` and validated nothing) and the
+  `Provider` JSDoc that imported a non-existent `antdModalAdapter`.
+
+**Breaking**
+
+- `ShadCNModalProps` / `createModalProps`: the `afterClose?: () => void` field is
+  replaced by `onOpenChangeComplete?: (open: boolean) => void` (Base UI's real
+  post-transition hook). Spreading `{...modal.modalProps}` onto a dialog is
+  unaffected (and stops leaking); code that read `modalProps.afterClose` by hand
+  should switch to `onOpenChangeComplete` (and guard on `open === false`).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -2,18 +2,19 @@
 
 ## Domain language
 
-<!-- Add project-specific terms and their definitions here. Example:
-
 - **Compose layer**: The `registry/ui/*` components that wrap shadcn primitives with flat props.
 - **Primitive**: The raw `components/ui/*` shadcn components with full composition freedom.
-- **Command-modal**: The modal state management library in `packages/command-modal/`.
--->
+- **Command-modal**: The imperative modal state-management library in `packages/command-modal/`.
+- **Handler**: The object `useModal()` returns — the modal's live state (`visible`, `args`, …) plus the imperative verbs (`show`, `hide`, `remove`, `resolve`, `reject`, `resolveHide`). The unit an Adapter consumes.
+- **Adapter** (`ModalPropsAdapter`): A pure function mapping a Handler to the prop shape one modal UI library expects (e.g. shadcn `{ open, onOpenChange }`, antd `{ open, onCancel, afterClose }`). The single seam by which command-modal stays UI-library-agnostic.
+- **First-class adapter**: An adapter the library ships, types, and supports. Scope: **shadcn** (default) and **antd v6**. Everything else is a BYO adapter.
+- **BYO adapter**: A user-supplied Adapter. Supported by the type system (must be fully type-safe to author and consume) but not shipped or maintained by the library.
+- **Resolution value** (result): The value a modal hands back to whoever opened it when it completes — what `await show(Modal)` settles with, set via `modal.resolve(value)`. Distinct from a **dismissal** (hide/remove/unregister without an explicit resolve), which settles the promise with `undefined`.
 
 ## Key decisions
-
-<!-- Link to ADRs or note important architectural choices. Example:
 
 - Dual-layer architecture: primitives (`components/ui/*`) + Compose layer (`registry/ui/*`)
 - 80/20 rule: Compose layer serves 80% of common use cases
 - `components/ui/**` is read-only, only modified via shadcn CLI
--->
+- command-modal's only UI-library coupling is the Adapter seam; the core stays UI-agnostic. First-class targets are shadcn + antd v6; other libraries are typed-but-BYO. See [ADR-0001](docs/adr/0001-adapter-seam-and-typed-factory.md).
+- A modal's resolve (result) type is carried on `create<Props, Result>`, not at the `show()` call site. See [ADR-0002](docs/adr/0002-resolve-type-on-create.md).

--- a/content/docs/components/modal.mdx
+++ b/content/docs/components/modal.mdx
@@ -99,7 +99,7 @@ Any component created with `Modal.create` can be driven imperatively — `useMod
 | `trigger` | `ReactElement` | - | Rendered as the `DialogTrigger`. |
 | `showCloseButton` | `boolean` | `true` | The top-right close button. |
 | `disablePointerDismissal` | `boolean` | `false` | Prevents closing via outside clicks. |
-| `afterClose` | `() => void` | - | Called after the close animation completes. |
+| `onOpenChangeComplete` | `(open: boolean) => void` | - | Base UI's post-transition hook, fired after the open/close animation completes. Forwarded to the underlying Dialog. |
 
 Class overrides: `className` (dialog content), `headerClassName`, `titleClassName`, `descriptionClassName`, `contentClassName` (body), `footerClassName`.
 

--- a/content/docs/packages/command-modal.mdx
+++ b/content/docs/packages/command-modal.mdx
@@ -233,32 +233,36 @@ interface CommandModalProviderProps {
 Creates a modal component with proper typing.
 
 ```tsx
-function create<TProps = Record<string, unknown>>(
+function create<TProps = object, TResult = unknown>(
   component: React.ComponentType<TProps>
-): React.ComponentType<TProps>
+): CreateModalComponent<TProps, TResult>
 ```
 
 **Type Parameters:**
-- `TProps` - Props type for your modal component
+- `TProps` - Props type for your modal component (validated at `show()` time)
+- `TResult` - The type `show()` resolves with (what you pass to `modal.resolve()`); defaults to `unknown`
 
-**Returns:** A wrapped component that can be used with CommandModal
+**Returns:** A wrapped component carrying both `TProps` and `TResult`, for use with `show()`
 
 ### CommandModal.show()
 
-Shows a modal and returns a promise.
+Shows a modal and returns a promise. Both the args and the resolved type are
+inferred from the component created by `create<Props, Result>` — no explicit
+type argument:
 
 ```tsx
-function show<TProps, TResult = unknown>(
-  modal: React.ComponentType<TProps>,
-  props?: TProps
-): Promise<TResult>
+// Component form — args (Props) and result (Result) inferred from the component:
+function show<C>(modal: C, args?: Partial<Props>): Promise<Result>
+// String-id form — the id carries no type, so pass the result explicitly:
+function show<T = unknown>(modal: string, args?: Record<string, unknown>): Promise<T>
 ```
 
 **Parameters:**
-- `modal` - Modal component created with `CommandModal.create()`
-- `props` - Props to pass to the modal
+- `modal` - Modal component created with `CommandModal.create()` (or a string id)
+- `args` - Args passed to the modal component (validated against its `Props`)
 
-**Returns:** Promise that resolves when modal calls `modal.resolve()`
+**Returns:** Promise that resolves with the value passed to `modal.resolve()`
+(typed `Result`), or `undefined` if the modal is dismissed without resolving.
 
 ### CommandModal.hide()
 
@@ -286,10 +290,12 @@ function remove(modal: React.ComponentType): void
 
 ### CommandModal.useModal()
 
-Hook to access modal controls within a modal component.
+Hook to access modal controls within a modal component. Inside the body, call
+it with no argument (the modal id comes from context); the resolve type is the
+`Result` you declared on `create<Props, Result>`.
 
 ```tsx
-function useModal<TResult = unknown>(): CommandModalHandler<TResult>
+const modal = useModal(); // inside a create()'d modal
 ```
 
 **Returns:** Modal handler object with the following properties:
@@ -358,71 +364,95 @@ with the command-modal reducer. Most callers should use
 
 ## Advanced Usage
 
-### Custom Modal Adapters
+### Adapters
 
-CommandModal uses adapters to work with different UI libraries. The default adapter works with shadcn/ui, but you can create custom adapters.
+An **adapter** maps the modal handler to the prop shape one UI library expects.
+It is the single seam by which command-modal stays UI-library-agnostic. Each
+adapter emits its own library's real prop names.
 
-#### Default shadcn Adapter
+#### Default shadcn adapter
+
+shadcn/ui (Base UI Dialog) is the zero-config default — you don't configure
+anything. The default `createModalProps` emits Base UI's real props
+`{ open, onOpenChange, onOpenChangeComplete }`, wiring teardown to
+`onOpenChangeComplete` (guarded on close) so `<Dialog {...modal.modalProps}>`
+removes the modal once its close animation finishes:
 
 ```tsx
-import CommandModal, { shadcnModalAdapter } from '@easy-shadcn/command-modal';
-
-// The shadcn adapter is used by default
-<CommandModal.Provider>
-  <App />
-</CommandModal.Provider>
-
-// Or explicitly configure it
-<CommandModal.Provider config={{ modalPropsAdapter: shadcnModalAdapter }}>
-  <App />
-</CommandModal.Provider>
+import { createModalProps } from '@easy-shadcn/command-modal';
+// Used automatically; you only import it to build on top of it.
 ```
 
-#### Creating Custom Adapters
+#### Typed adapters with `createCommandModal` (antd, …)
 
-Create an adapter for your UI library:
+For a non-shadcn library, pair its adapter with `createCommandModal` once. The
+factory returns a `Provider` pre-bound to the adapter and a `useModal` whose
+`modalProps` is **statically typed** as that library's props — no casts. **antd
+v6** is first-class: an official `antdModalProps` adapter ships at the `/antd`
+subpath (no `antd` dependency is added to the core).
+
+Set it up once in an app-local barrel, and re-export the imperative verbs from
+the same module so app code has a single import source:
 
 ```tsx
-import type { ModalPropsAdapter } from '@easy-shadcn/command-modal';
+// lib/modal.ts — the only command-modal entry point in your app
+import {
+  createCommandModal,
+  show,
+  hide,
+  remove,
+  create,
+} from '@easy-shadcn/command-modal';
+import { antdModalProps } from '@easy-shadcn/command-modal/antd';
 
-// Example: Ant Design adapter
-interface AntdModalProps {
-  open: boolean;
-  onCancel: () => void;
-  afterClose: () => void;
-}
+// Call the factory once at module scope (never inside a render).
+export const { Provider, useModal } = createCommandModal(antdModalProps);
+export { show, hide, remove, create };
+```
 
-const antdModalAdapter: ModalPropsAdapter<AntdModalProps> = (handler) => ({
-  open: handler.visible,
-  onCancel: () => handler.hide(),
-  afterClose: () => {
-    handler.resolveHide();
-    if (!handler.keepMounted) {
-      handler.remove();
-    }
-  },
+```tsx
+// any feature file
+import { useModal, show } from '@/lib/modal';
+
+const EditUser = create(() => {
+  const modal = useModal();
+  // modal.modalProps is typed as antd's { open, onCancel, afterClose }
+  return <Modal {...modal.modalProps}>…</Modal>;
 });
-
-// Use the custom adapter
-<CommandModal.Provider config={{ modalPropsAdapter: antdModalAdapter }}>
-  <App />
-</CommandModal.Provider>
 ```
 
-#### Example: Material-UI Adapter
+> **Guard the footgun.** The package root also exports a `useModal` typed for
+> shadcn. If you accidentally import it instead of your factory's, `modalProps`
+> silently reverts to the shadcn shape. Forbid the root import in your project
+> so it fails in CI instead of at runtime:
+>
+> ```jsonc
+> // eslint config — no-restricted-imports
+> {
+>   "paths": [{
+>     "name": "@easy-shadcn/command-modal",
+>     "importNames": ["useModal"],
+>     "message": "Import useModal from your createCommandModal factory (e.g. @/lib/modal)."
+>   }]
+> }
+> ```
+
+#### Writing your own adapter (BYO)
+
+Any UI library works through a typed adapter — emit its real prop names and
+wire teardown to its post-close hook:
 
 ```tsx
 import type { ModalPropsAdapter } from '@easy-shadcn/command-modal';
 
-interface MuiDialogProps {
+// Example: Material UI <Dialog>
+type MuiDialogProps = {
   open: boolean;
   onClose: () => void;
-  TransitionProps?: {
-    onExited?: () => void;
-  };
-}
+  TransitionProps?: { onExited?: () => void };
+};
 
-const muiDialogAdapter: ModalPropsAdapter<MuiDialogProps> = (handler) => ({
+const muiModalProps: ModalPropsAdapter<MuiDialogProps> = (handler) => ({
   open: handler.visible,
   onClose: () => handler.hide(),
   TransitionProps: {
@@ -434,6 +464,8 @@ const muiDialogAdapter: ModalPropsAdapter<MuiDialogProps> = (handler) => ({
     },
   },
 });
+
+// Then: export const { Provider, useModal } = createCommandModal(muiModalProps);
 ```
 
 ### Keep Modal Mounted
@@ -551,26 +583,39 @@ CommandModal.show(UserForm, {
 
 ### Type-safe Results
 
+Declare a modal's resolve (result) type as the **second type argument to
+`create`**. It flows to `show()`, which infers both the args and the result
+with no explicit type argument and no cast:
+
 ```tsx
 interface FormResult {
   name: string;
   email: string;
 }
 
-const FormModal = CommandModal.create(() => {
-  const modal = CommandModal.useModal<FormResult>();
+const FormModal = CommandModal.create<{ defaultName?: string }, FormResult>(
+  ({ defaultName }) => {
+    const modal = CommandModal.useModal();
 
-  const handleSubmit = (data: FormResult) => {
-    modal.resolve(data); // Type-safe resolve
-    modal.hide();
-  };
+    const handleSubmit = (data: FormResult) => {
+      modal.resolve(data);
+      modal.hide();
+    };
 
-  return <Dialog {...modal.modalProps}>...</Dialog>;
-});
+    return <Dialog {...modal.modalProps}>...</Dialog>;
+  }
+);
 
-// TypeScript knows the result type
-const result: FormResult = await CommandModal.show(FormModal);
+// show() infers Promise<FormResult> AND validates the args.
+const result = await CommandModal.show(FormModal, { defaultName: 'Ada' });
+// result: FormResult
 ```
+
+The result type is declared at the definition site (not the `show()` call site)
+so that args-checking and a typed result can coexist — TypeScript has no partial
+type-argument inference, so pinning the result at the call site would disable
+args inference. The result type defaults to `unknown` when omitted, so modals
+whose result you don't consume need no extra annotation.
 
 ## Best Practices
 
@@ -685,15 +730,16 @@ CommandModal.show(MyModal);
 
 ## Troubleshooting
 
-### Modal Doesn't Close
+### Modal Doesn't Close (or leaks after closing)
 
-Ensure you're calling `afterClose` in your modal component:
+Spread `modal.modalProps` directly onto your dialog so the adapter's post-close
+hook reaches the underlying component. For the shadcn/Base UI default that hook
+is `onOpenChangeComplete`; if you forward props by hand, don't drop it, or the
+modal is never removed after it closes:
 
 ```tsx
-<Dialog
-  {...modal.modalProps}
-  // Make sure afterClose is called when animation completes
->
+// ✅ spread everything — open, onOpenChange, onOpenChangeComplete
+<Dialog {...modal.modalProps}>
   ...
 </Dialog>
 ```
@@ -744,11 +790,11 @@ and with more than one mounted the routing target is not guaranteed.
 ### Confirmation Dialog
 
 ```tsx
-const ConfirmDialog = CommandModal.create<{
-  title: string;
-  message: string;
-}>(({ title, message }) => {
-  const modal = CommandModal.useModal<boolean>();
+const ConfirmDialog = CommandModal.create<
+  { title: string; message: string },
+  boolean
+>(({ title, message }) => {
+  const modal = CommandModal.useModal();
 
   return (
     <AlertDialog {...modal.modalProps}>
@@ -790,9 +836,9 @@ if (confirmed) {
 ### Form Modal with Validation
 
 ```tsx
-const FormModal = CommandModal.create<{ defaultValues?: FormData }>(
+const FormModal = CommandModal.create<{ defaultValues?: FormData }, FormData>(
   ({ defaultValues }) => {
-    const modal = CommandModal.useModal<FormData>();
+    const modal = CommandModal.useModal();
     const [values, setValues] = useState(defaultValues || {});
     const [errors, setErrors] = useState({});
 

--- a/docs/adr/0001-adapter-seam-and-typed-factory.md
+++ b/docs/adr/0001-adapter-seam-and-typed-factory.md
@@ -1,0 +1,17 @@
+# Adapter seam + typed factory for multi-UI-library support
+
+command-modal must emit UI-library-specific modal props (shadcn the zero-config default, antd v6 first-class) while staying UI-agnostic and keeping the core zero-dependency. We keep a single **Adapter** seam (`handler → props`) and expose first-class typed support for non-default adapters through a `createCommandModal(adapter)` factory that returns a config-bound `{ Provider, useModal }` whose `modalProps` is typed to the adapter's return type — rather than threading a generic through `Provider`/`Context`/`useModal`.
+
+**Why a factory, not threaded generics:** React context can't carry a value-level generic into `useModal()`'s return type, so capturing `TModalProps` at the factory's closure boundary is the only way to make `modalProps` type-safe without a per-call type annotation.
+
+## Considered options
+
+- **Thread `TModalProps` through Provider → Context → useModal** — rejected: `useContext` erases the generic; the bare `useModal()` can't recover the adapter type.
+- **Ship owned mui/other adapters** — rejected: peer-dep + maintenance burden. Only **shadcn** and **antd v6** are first-class; everything else is typed-but-BYO.
+
+## Consequences
+
+- antd's adapter type is **hand-written** (`AntdModalProps = { open?, onCancel?, afterClose? }`, no `antd` import), mirroring the existing hand-written `ShadCNModalProps`, so the core keeps its "Zero dependencies" guarantee. The antd adapter ships at the `/antd` subpath export.
+- **Each adapter emits its own UI library's real prop names.** This corrects the shadcn adapter, which previously emitted the antd-ism `afterClose`: it now emits Base UI's real post-close hook `onOpenChangeComplete?: (open: boolean) => void` (verified against `@base-ui/react@1.4.0`), so `<Dialog {...modal.modalProps}>` works on a raw Base UI dialog without leaking. `ShadCNModalProps` changes `afterClose → onOpenChangeComplete` — a breaking change shipped as a 0.x **minor** bump (0.2.0 → 0.3.0) per semver's 0.x convention.
+- The package root still exports a shadcn-typed `useModal`. antd consumers must use the **factory's** `useModal` — mitigated by an app-local barrel that re-exports the factory output plus the root verbs, and a `no-restricted-imports` lint rule banning `useModal` from the package root.
+- The factory's `useModal` is a **type-only reskin** of the base hook (the runtime adapter is already applied via the config context the factory's Provider injects); it must not re-wrap/re-run the adapter, which would double-invoke it and break memoization.

--- a/docs/adr/0002-resolve-type-on-create.md
+++ b/docs/adr/0002-resolve-type-on-create.md
@@ -1,0 +1,11 @@
+# Carry the modal's resolve (result) type on create()
+
+`show(modal)` settles with the value passed to `modal.resolve(...)`, but TypeScript can't infer that result type from inside the modal body (inference flows through signatures, not function bodies, and `resolve` comes from a decoupled `useModal()` hook). The old `show<T, C>` overloads also degraded to the `modal: string` overload whenever `T` was given explicitly, because supplying one type argument failed overload ①'s two-parameter arity. We carry the optional resolve type `R` as a second type parameter on `create<Props, R>` (default `unknown`), so `show(Comp, args)` infers **both** the args and `Promise<R>` with zero explicit type arguments.
+
+**Why definition-site, not call-site:** declaring `R` on `create` frees the call-site inference slot, so args-checking and a typed result coexist. The call-site form `show<R>(Comp)` can't do this — TypeScript has no partial type-argument inference, so pinning `R` stops the component (and thus the args) from being inferred. You get args **xor** result, never both.
+
+## Consequences
+
+- Typing a result requires writing `Props` explicitly too (`create<Props, R>`) — same no-partial-inference limitation. When you don't need a typed result, `create<Props>(Comp)` or `create(Comp)` behaves exactly as before (`R = unknown`).
+- The body's no-arg `useModal().resolve` stays `unknown`-typed, so `R` is an author-declared contract surfaced to the **caller**, not enforced at the `resolve()` call site.
+- Additive and non-breaking: existing `create<P>(Comp)` and untyped `show(Comp)` callers are unaffected. The string-id path keeps `show<T>(modal: string)` with explicit `T`, since a string id carries no component to infer from.

--- a/docs/specs/2026-06-29-command-modal-type-safety.md
+++ b/docs/specs/2026-06-29-command-modal-type-safety.md
@@ -1,0 +1,241 @@
+# Command-Modal 类型安全与多 UI 库一等支持（command-modal-type-safety）
+
+> Status: Draft
+> Owner: Simon
+> Created: 2026-06-29
+> Related: [ADR-0001](../adr/0001-adapter-seam-and-typed-factory.md) · [ADR-0002](../adr/0002-resolve-type-on-create.md) · [CONTEXT.md](../../CONTEXT.md)
+
+## 1. Context
+
+`@easy-shadcn/command-modal`（本地 0.2.0）的 README 宣称两件事：**"Type-safe — Full TypeScript support"** 与 **"Works with any modal UI library through adapters"**。实测（已用 antd 实接验证）这两句都没兑现：
+
+- **自定义 adapter 的类型链全程断裂**。`CommandModalConfig<TModalProps>` 有泛型，但 `TModalProps` 没有流过 Provider → Context → useModal，`useModal().modalProps` 被写死成 `ShadCNModalProps`。非 shadcn 用户每个消费点都要 `as unknown as`——作者自己的测试就在 cast（`test/config.test.tsx`）。
+- **`show<T>(Comp)` 显式标注返回类型会编译报错**。`show` 重载①有两个无默认值的类型参数，显式只给一个 `<T>` 会落到 `modal: string` 的重载②，报"组件不是 string"。要么放弃标注、要么 `as Promise<T>`。
+- **默认 adapter 吐了个 antd 概念 `afterClose`**，而本仓库 Dialog 用的是 Base UI（`@base-ui/react`，无 `afterClose`，真名是 `onOpenChangeComplete`）。照 README 把 `modal.modalProps` spread 到裸 `<Dialog>` 会**静默忽略 `afterClose` → `remove()` 永不触发 → reducer 条目与 HOC 实例残留泄漏**。
+- **缺官方 antd adapter 与类型入口**。`context.tsx` 的 Provider JSDoc 甚至示范 `import { antdModalAdapter }`——一个根本不存在的导出。
+- **死类型 `CommandModalArgs<T>`** 对任意 `React.FC` 塌缩成 `Record<string, unknown>`（作者注释已自认"type-checks nothing"），仍被 `show` 实现签名引用，误导。
+- **README `[Full Documentation]` 是 `your-docs-url.com` 占位死链**，且最易踩坑的自定义 adapter / TypeScript 现状完全没写。
+
+本 spec 把上述六项收敛成一次连贯的类型安全 + 多 UI 库一等支持的改造。
+
+## 2. Goals & Non-Goals
+
+### Goals
+
+- G1：让**任意 BYO adapter** 的 `modalProps` 在消费端类型贯通，零 `as`。
+- G2：让 **antd v6** 成为与 shadcn 对等的**一等公民**（官方 adapter + 类型入口），shadcn 仍是零配置默认。
+- G3：让 `show()` 能**同时**类型安全地拿到 args 校验与 resolve 结果类型。
+- G4：让默认 shadcn adapter 产出 **Base UI 真实 prop**，README 旗舰示例 `<Dialog {...modal.modalProps}>` 真能跑、不泄漏。
+- G5：core 入口保持 **Zero dependencies**。
+- G6：删除误导性死类型，补真实文档链接与 antd recipe。
+
+### Non-Goals
+
+- **NG1：不内置/维护 mui 及其它库的 adapter**。它们是"类型安全但 BYO"，仅文档给 recipe（见 ADR-0001）。
+- **NG2：不把 `TModalProps` 泛型真正穿过 `Provider`/`Context`/`useModal`**。React context 在值层面擦除泛型，改用工厂在闭包边界捕获（见 ADR-0001）。
+- **NG3：不在 `create` 之外提供"调用处覆盖 resolve 类型"的写法**（`show<R>(Comp)`）。TS 无部分类型推断，调用处标注会牺牲 args 校验（见 ADR-0002）。
+- **NG4：不引入 antd 为运行时/类型硬依赖**。`AntdModalProps` 手写、零 import。
+- **NG5：不升 1.0**。破坏性变更按 0.x semver 约定走 minor（0.2.0 → 0.3.0）。
+- **NG6：不改动 `components/ui/**`**（只读，仅 shadcn CLI 维护）。
+
+## 3. User Stories
+
+1. As an antd 应用开发者, I want `useModal(MyModal).modalProps` 静态类型就是 antd 的 props, so that 我能直接 `<Modal {...modalProps}>` 而不写任何 `as`。
+2. As an antd 应用开发者, I want 一个官方的 `antdModalProps` adapter, so that 我不必自己手写 `{ open, onCancel, afterClose }` 映射。
+3. As an antd 应用开发者, I want 一行 `createCommandModal(antdModalProps)` 就拿到类型贯通的 `Provider` 和 `useModal`, so that 我按一次 opt-in 后体验与 shadcn 用户对等。
+4. As an antd 应用开发者, I want 把 adapter 装配收敛到一个 app 本地 barrel 文件, so that 应用代码只从一个出口 import，不暴露包根。
+5. As an antd 应用开发者, I want 一条 `no-restricted-imports` 规则禁止从包根 import `useModal`, so that 手滑 import 错的 `useModal`（shadcn 类型）会在 CI 报错而不是运行时静默错配。
+6. As a shadcn 应用开发者, I want 零配置默认仍是 shadcn, so that 我什么都不配就拿到正确类型。
+7. As a shadcn 应用开发者, I want `<Dialog {...modal.modalProps}>` 直接产出 Base UI 真实 prop, so that 关闭后 `remove()` 正常触发、不泄漏。
+8. As a 模态框作者, I want 用 `create<Props, Result>` 声明这个 modal 收什么、还什么, so that `await show(MyModal, args)` 同时校验 args 并返回 `Promise<Result>`。
+9. As a 模态框作者, I want `Result` 可选且默认 `unknown`, so that 不在乎返回值的 modal 一行都不用多写、行为与现在一致。
+10. As a 调用方, I want `await show(ConfirmModal)` 在 `create<{}, boolean>` 下返回 `Promise<boolean>`, so that 确认框结果天然类型化、无需 cast。
+11. As a 调用方, I want 传错 args（拼写错误的字段）时编译报错, so that 我在写代码时就发现问题。
+12. As a BYO adapter 作者, I want `ModalPropsAdapter<TMine>` 与工厂配合后类型贯通, so that 即便我接的是冷门库也享受同等类型安全。
+13. As a 库使用者, I want core 入口零依赖, so that 我只用 shadcn 时不会被 antd 类型或代码连累。
+14. As a 库使用者, I want README 有可点击的真实文档链接, so that 我能找到 antd recipe 与 TypeScript 指南。
+15. As a 库维护者, I want 工厂只返回 `{ Provider, useModal }`（adapter 真正改变的那两个）, so that 不产生 `show` 等函数的双 import 路径与漂移。
+16. As a 库维护者, I want 根与工厂两套 `useModal` 重载走单源类型, so that 二者不会 copy-paste 后漂移。
+17. As a 库维护者, I want 每个 adapter 只吐自己库的真实 prop 名, so that 类型不再交叉污染（shadcn 不再借 antd 的 `afterClose`）。
+18. As a 库维护者, I want 删掉死类型 `CommandModalArgs` 与不存在的 `antdModalAdapter` JSDoc, so that 公共表面不再误导。
+19. As a 文档读者, I want docs 站有 antd recipe、自定义 adapter 指南、resolve 类型说明, so that 我照着就能接任意库。
+20. As a 模态框作者, I want `modal.resolve(value)` 在 `create<P,R>` 下被类型为 `(value: R)`（对外契约层面）, so that 调用方拿到的结果类型与我声明的一致。
+21. As a CI/构建, I want `/antd` 子路径在 `node` 与 `bundler` 解析下都能 resolve 类型, so that 不出现"运行时能 import、类型却找不到"。
+
+## 4. Functional Requirements (EARS)
+
+- FR1：WHEN 调用 `createCommandModal(adapter)` THE SYSTEM SHALL 返回 `{ Provider, useModal }`，其中 `Provider` 已绑定 `config={{ modalPropsAdapter: adapter }}`。
+- FR2：WHEN 在工厂 `Provider` 子树内调用工厂 `useModal(C)` THE SYSTEM SHALL 使 `modalProps` 的静态类型为该 adapter 的返回类型 `TModalProps`。
+- FR3：THE SYSTEM SHALL 使工厂 `useModal` 在运行时与 base `useModal` 行为完全一致（类型换肤），不得二次调用 adapter、不得破坏 base 的 memo 稳定性。
+- FR4：WHEN 未提供 config THE SYSTEM SHALL 使包根 `useModal` 的 `modalProps` 保持 `ShadCNModalProps`（shadcn 为零配置默认）。
+- FR5：THE SYSTEM SHALL 从 `@easy-shadcn/command-modal/antd` 导出 `antdModalProps`（类型 `ModalPropsAdapter<AntdModalProps>`），且其实现不 import `antd`。
+- FR6：`antdModalProps(handler)` SHALL 返回 `{ open: handler.visible, onCancel: () => handler.hide(), afterClose: () => { handler.resolveHide(); IF !handler.keepMounted THEN handler.remove() } }`。
+- FR7：`createModalProps(handler)`（shadcn）SHALL 返回 `{ open, onOpenChange, onOpenChangeComplete }`；其中 `onOpenChangeComplete(open)` IF `open === false` THEN 调用 `handler.resolveHide()` 并 IF `!handler.keepMounted` THEN `handler.remove()`。
+- FR8：THE SYSTEM SHALL NOT 再让 `createModalProps` / `ShadCNModalProps` 产出或声明 `afterClose`。
+- FR9：WHEN 以 `create<Props, Result>(Comp)` 创建组件并 `show(Comp, args)` THE SYSTEM SHALL 推断 `args` 为 `Partial<Props>` 并返回 `Promise<Result>`，无需任何显式类型实参。
+- FR10：WHEN 省略 `Result`（`create<Props>` 或 `create(Comp)`）THE SYSTEM SHALL 令 `Result` 默认为 `unknown`，`show(Comp)` 返回 `Promise<unknown>`，行为与现状一致。
+- FR11：WHEN 以字符串 id 调用 `show<T>(id, args)` THE SYSTEM SHALL 返回 `Promise<T>`（字符串 id 不携带组件，沿用显式 `T`）。
+- FR12：THE SYSTEM SHALL 删除 `CommandModalArgs` 类型，并将其在内部签名处的引用替换为 `Record<string, unknown>`。
+- FR13：THE SYSTEM SHALL 移除 `context.tsx` 中引用不存在的 `antdModalAdapter` 的 JSDoc，替换为真实 API 示例。
+- FR14：THE SYSTEM SHALL 将包 README 的 `Full Documentation` 链接改为 `https://easy-shadcn.vercel.app/docs/packages/command-modal`。
+- FR15：THE SYSTEM SHALL 更新 registry `Modal` wrapper 以消费 `onOpenChangeComplete`（而非自家 `afterClose` 桥接），使 `<Modal {...modalProps}>` 仍正常 remove。
+
+## 5. Data Model
+
+不涉及持久化。运行时状态仍是 reducer `CommandModalStore`（`{ [modalId]: { id, args, visible, delayVisible, keepMounted } }`），本 spec 不改其形状。
+
+## 6. State Machine（与 adapter 关闭路径相关）
+
+一个 modal 实例的关闭生命周期（adapter 负责把 UI 库事件接到这条链）：
+
+```
+visible:true ──UI 用户关闭（ESC/遮罩/取消按钮）──▶ hide()  → visible:false（开始退出动画）
+                                                            │
+        退出动画结束（shadcn: onOpenChangeComplete(false)；antd: afterClose）
+                                                            ▼
+                                       resolveHide() ；若 !keepMounted 则 remove()
+                                                            │
+                                  remove() 删 reducer 条目 → placeholder 卸载 HOC
+```
+
+**关键不变量**：`remove()` 由"退出动画完成"事件驱动，必须经由各 UI 库的真实完成钩子（shadcn=`onOpenChangeComplete`，antd=`afterClose`）。若 adapter 吐的钩子名 UI 库不认识，这条链断裂即泄漏（即旧 P1-1）。
+
+## 7. Type Design（关键类型机制）
+
+### 7.1 工厂类型换肤
+
+工厂的 `useModal` 是 base `useModal` 的**同一个函数引用**，仅收窄返回类型：
+
+```ts
+type UseModalReturn<TModalProps> = {
+  (modal?: string, args?: Record<string, unknown>):
+    CommandModalHandler & { modalProps: TModalProps }
+  <C extends CreateModalComponent<any, any>>(modal: C, args?: Partial<ModalInnerProps<C>>):
+    Omit<CommandModalHandler<any, ResolveType<C>>, "show">
+      & { show: (args?: Partial<ModalInnerProps<C>>) => Promise<ResolveType<C>> }
+      & { modalProps: TModalProps }
+}
+// 库内一次受控断言，把"每个调用点的 cast"吸收到此一处
+const useModal = baseUseModal as unknown as UseModalReturn<TModalProps>
+```
+
+根 `useModal` 用 `UseModalReturn<ShadCNModalProps>`，工厂用 `UseModalReturn<TModalProps>`——**单源**，禁止 copy-paste 两套重载。
+
+### 7.2 resolve 结果类型挂在 create
+
+`Result` 写在定义处（`create`），不写在调用处（`show`），以释放调用处的推断名额，使 args 与 result 共存（ADR-0002）：
+
+```ts
+type CreateModalComponent<T = object, R = unknown> =
+  React.FC<Partial<T> & CommandModalHocProps> & { readonly __resolveType?: R } // phantom brand
+type ResolveType<C> = C extends { __resolveType?: infer R } ? R : unknown
+
+create<P extends object, R = unknown>(Comp): CreateModalComponent<P, R>
+show<C extends CreateModalComponent<any, any>>(modal: C, args?: Partial<ModalInnerProps<C>>): Promise<ResolveType<C>>
+show<T = unknown>(modal: string, args?: Record<string, unknown>): Promise<T>
+```
+
+> 上述类型片段编码的是决策（非可运行实现）：phantom brand `__resolveType` 仅存在于类型层，运行时无此字段。
+
+## 8. API Contracts（对外公共表面）
+
+| 导出 | 入口 | 形状/契约 | 备注 |
+|---|---|---|---|
+| `createCommandModal(adapter)` | 包根 | `→ { Provider, useModal }` | MIN 返回；类型换肤 |
+| `antdModalProps` | `/antd` 子路径 | `ModalPropsAdapter<AntdModalProps>` | 手写零依赖 |
+| `AntdModalProps` (type) | `/antd` 子路径 | `{ open?; onCancel?; afterClose? }` | 不 import antd |
+| `createModalProps` | 包根 | `→ ShadCNModalProps` | 改吐 `onOpenChangeComplete` |
+| `ShadCNModalProps` (type) | 包根 | `{ open?; onOpenChange?; onOpenChangeComplete? }` | **破坏性**：移除 `afterClose` |
+| `create<P, R>(Comp)` | 包根 | `→ CreateModalComponent<P, R>` | `R` 默认 `unknown`，additive |
+| `show(Comp, args)` / `show<T>(id, args)` | 包根 | `→ Promise<ResolveType<C>>` / `Promise<T>` | 组件路径零类型实参 |
+| ~~`CommandModalArgs`~~ | — | **删除** | 内部专用，零公开导出 |
+
+**app 本地 barrel（antd 用户的唯一出口，文档示范）**：
+```ts
+// src/lib/modal.ts
+import { createCommandModal, show, hide, remove, create } from '@easy-shadcn/command-modal'
+import { antdModalProps } from '@easy-shadcn/command-modal/antd'
+export const { Provider, useModal } = createCommandModal(antdModalProps)
+export { show, hide, remove, create }
+```
+
+## 9. Key Design Decisions (ADR)
+
+完整记录见 [ADR-0001](../adr/0001-adapter-seam-and-typed-factory.md) 与 [ADR-0002](../adr/0002-resolve-type-on-create.md)。摘要：
+
+### ADR-1: 工厂而非穿透泛型实现 adapter 类型贯通
+
+**Decision**：`createCommandModal(adapter)` 在闭包边界捕获 `TModalProps`，返回类型贯通的 `{ Provider, useModal }`。
+
+**Why**：React context 在值层面擦除泛型，`useContext` 无法把 per-Provider 的 `TModalProps` 带回 `useModal()` 返回类型。穿透泛型做不到，逐调用点 `useModal<T>()` 又到处重复易漏。工厂捕获一次即可。备选"穿透泛型"被否。
+
+### ADR-2: 每个 adapter 吐自己库的真实 prop 名
+
+**Decision**：shadcn=`onOpenChangeComplete`（Base UI 真名，已对 `@base-ui/react@1.4.0` 验证），antd=`afterClose`（antd 真名）。`ShadCNModalProps` 破坏性移除 `afterClose`。
+
+**Why**：旧"shadcn" adapter 借了 antd 概念 `afterClose`，Base UI 不认识，裸 `<Dialog>` 泄漏。让每个 adapter 吐真名是 antd 一等公民后唯一自洽的不变量，并修好 README 旗舰示例。破坏面仅 registry wrapper + 测试（自有），库外裸 Dialog 用户本就泄漏、此改是修好。
+
+### ADR-3: resolve 结果类型挂 create 而非 show 调用处
+
+**Decision**：`create<Props, Result>` 携带 `R`（默认 `unknown`），`show(Comp)` 零类型实参同时推出 args 与 `Promise<R>`。
+
+**Why**：TS 无部分类型推断；调用处 `show<R>(Comp)` 会占掉推断名额、牺牲 args 校验（args xor result）。定义处声明 `R` 释放该名额，args 与 result 共存。
+
+### ADR-4: antd 类型手写零依赖 + `/antd` 子路径
+
+**Decision**：`AntdModalProps` 手写 `{ open?, onCancel?, afterClose? }`，置于 `/antd` 子路径导出。
+
+**Why**：adapter 只产出这 3 个 prop（其余 antd props 从 JSX 现场给），手写即够且与 antd v5→v6 稳定 prop 对齐，低漂移。保住 core "Zero dependencies"；子路径隔离命名并为"未来若需精确对齐 antd 真实 ModalProps"留对冲。
+
+### ADR-5: 工厂只返回 `{ Provider, useModal }`（MIN）
+
+**Decision**：不把 `show/hide/remove/create` 等打包进工厂返回。
+
+**Why**：这些函数签名与 adapter 无关，打包进去会产生双 import 路径与漂移，且暗示它们 adapter-aware（虚假作用域）。其 DX 红利由用户的 app 本地 barrel 完全回收。
+
+## 10. Acceptance Criteria
+
+- AC1：GIVEN `const { useModal } = createCommandModal(antdModalProps)` WHEN 在其 Provider 内 `useModal(MyModal)` THEN `modalProps` 类型为 `AntdModalProps` 且无需任何 `as`。
+- AC2：GIVEN 工厂 Provider 已挂载 WHEN 触发 modal 显示 THEN 运行时 `modalProps` 由 antd adapter 产出（`onCancel`/`afterClose` 存在），且 base `useModal` 仅被调用一次（无双跑 adapter）。
+- AC3：GIVEN shadcn 默认 adapter WHEN `<Dialog {...modal.modalProps}>` 关闭并完成退出动画 THEN `onOpenChangeComplete(false)` 触发 `resolveHide()`，且 `keepMounted=false` 时触发 `remove()`，reducer 条目被清除。
+- AC4：GIVEN `const M = create<{ userId: string }, User>(Inner)` WHEN `const u = await show(M, { userId: 'x' })` THEN `u` 类型为 `User` 且 `{ userId }` 被类型校验（拼错字段编译报错）。
+- AC5：GIVEN `const C = create<{}, boolean>(Inner)` WHEN `await show(C)` THEN 返回类型为 `Promise<boolean>`。
+- AC6：GIVEN `create<Props>(Inner)`（省略 Result）WHEN `show(Comp, args)` THEN 返回 `Promise<unknown>` 且 args 仍被校验（与现状一致）。
+- AC7：GIVEN 包根 `useModal` WHEN 不配置 adapter THEN `modalProps` 类型仍为 `ShadCNModalProps`。
+- AC8：GIVEN `import { antdModalProps } from '@easy-shadcn/command-modal/antd'` WHEN 在 `node` 与 `bundler` 两种 `moduleResolution` 下类型检查 THEN 均能 resolve，无类型错误。
+- AC9：GIVEN 代码库 WHEN grep `afterClose` 于 shadcn 路径（`createModalProps`/`ShadCNModalProps`）THEN 无命中。
+- AC10：GIVEN 代码库 WHEN grep `CommandModalArgs` THEN 无命中（已删除）。
+- AC11：GIVEN 包 README WHEN 检查 `Full Documentation` 链接 THEN 指向真实 docs URL，无 `your-docs-url.com`。
+
+## 10.1 Testing Strategy
+
+**好测试的标准**：只断言外部可观察行为（adapter 产出的 props、调用 handler 动词的副作用、`show` 的返回类型/settle 值），不耦合内部实现细节（reducer action 名、内部 ref）。
+
+| 模块 | 测什么 | 类型 | 现成范式 |
+|---|---|---|---|
+| M1 `antdModalProps` | 给定 handler，断言返回 `{ open, onCancel, afterClose }` 形状；调用各回调触发 `hide`/`resolveHide`/`remove` | 运行时 | `test/modalProps.test.tsx` |
+| M1 `createModalProps`(shadcn) | 断言返回 `{ open, onOpenChange, onOpenChangeComplete }`；`onOpenChangeComplete(false)` 触发 `resolveHide`+`remove`（防泄漏回归） | 运行时 | 同上 |
+| M2 工厂 | Provider 注入 adapter；其内 `useModal` 运行时产出 adapter 形状 `modalProps`；base `useModal` 不被二次包裹 | 运行时 | `test/config.test.tsx` |
+| M3 类型 | `show(create<P,R>(C))→Promise<R>` 且 args 校验；工厂 `useModal(C).modalProps:TModalProps`；根 `useModal` 仍 `ShadCNModalProps`；`show<T>(string)→Promise<T>` | 类型断言（`expectTypeOf`，零新依赖） | 新增 `test/types.test-d.ts` 类范式 |
+| M5 registry Modal | `<Modal {...modalProps}>` 关闭后仍触发 remove | 运行时 | `registry/ui/modal/modal.test.tsx` |
+| M4 `/antd` 子路径 | 冒烟：能 import `antdModalProps` 且类型 resolve | 构建/冒烟 | — |
+
+M6 文档不测。覆盖率门槛维持 lines 90 / functions 90 / branches 85 / statements 90。
+
+## 11. Out of Scope
+
+- 内置 mui 或其它库 adapter（NG1）。
+- 把泛型真正穿过 Provider/Context/useModal（NG2）。
+- 调用处覆盖 resolve 类型 `show<R>(Comp)`（NG3）。
+- antd 作为运行时/类型硬依赖（NG4）。
+- 1.0 / 多 Provider 路由语义变更（沿用现状）。
+- 改动 `components/ui/**`（只读）。
+- 修改 reducer / `CommandModalStore` 形状。
+
+## 12. References
+
+- ADR：[0001 adapter 接缝 + 工厂](../adr/0001-adapter-seam-and-typed-factory.md)、[0002 resolve 类型挂 create](../adr/0002-resolve-type-on-create.md)
+- 词汇表与关键决策：[CONTEXT.md](../../CONTEXT.md)
+- 关键文件锚点：`packages/command-modal/src/{useModal.tsx,actions.tsx,context.tsx,type.ts,index.ts}`、`registry/ui/modal/modal.tsx`、`components/ui/dialog.tsx`
+- 外部契约：`@base-ui/react@1.4.0` `DialogRoot.Props`（`onOpenChangeComplete: (open: boolean) => void`）；antd v6 Modal（`open` / `onCancel` / `afterClose`）
+- 文档落点：包 `README.md`、`content/docs/packages/command-modal.mdx`

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -10,6 +10,7 @@
 
 | 更新日期 | 规格 | 说明 |
 | --- | --- | --- |
+| 2026-06-29 | [Command-Modal 类型安全](./2026-06-29-command-modal-type-safety.md) | adapter 类型贯通工厂、antd v6 一等支持、resolve 类型挂 create、shadcn 吐 Base UI 真名修泄漏 |
 | 2026-06-10 | [Date Picker](./2026-06-10-date-picker.md) | Compose Date Picker 的模式、输入提交、受控状态与 Calendar 集成契约 |
 | 2026-06-10 | [Table](./2026-06-10-table.md) | Compose Table 的列定义、行 key、选择、状态与可访问性契约 |
 | 2026-06-02 | [Select](./2026-06-02-select.md) | Compose Select 的模式、状态、clearable 与远程加载契约 |

--- a/packages/command-modal/README.md
+++ b/packages/command-modal/README.md
@@ -40,9 +40,38 @@ const MyModal = CommandModal.create(() => {
 CommandModal.show(MyModal);
 ```
 
+## Typed results
+
+Declare a modal's resolve type on `create` and `show` infers it — no casts,
+args still checked:
+
+```tsx
+const EditUser = CommandModal.create<{ userId: string }, User>(/* … */);
+
+const user = await CommandModal.show(EditUser, { userId }); // user: User
+```
+
+## Other UI libraries (antd, …)
+
+shadcn is the zero-config default. For another library, pair its adapter with
+`createCommandModal` once in an app-local module — `useModal().modalProps` is
+then typed for that library:
+
+```tsx
+// lib/modal.ts
+import { createCommandModal } from '@easy-shadcn/command-modal';
+import { antdModalProps } from '@easy-shadcn/command-modal/antd';
+
+export const { Provider, useModal } = createCommandModal(antdModalProps);
+```
+
+`antd` is first-class (official adapter at the `/antd` subpath, no `antd`
+dependency added to the core). Any other library works via your own typed
+adapter. See the docs for the full recipe (barrel re-export + `no-restricted-imports`).
+
 ## Documentation
 
-📚 **[Full Documentation](https://your-docs-url.com/docs/packages/command-modal)**
+📚 **[Full Documentation](https://easy-shadcn.vercel.app/docs/packages/command-modal)**
 
 Comprehensive guides including:
 

--- a/packages/command-modal/package.json
+++ b/packages/command-modal/package.json
@@ -27,6 +27,7 @@
     "build": "tsdown",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:types": "vitest --run --typecheck.only",
     "test:coverage": "vitest run --coverage"
   },
   "keywords": [],

--- a/packages/command-modal/package.json
+++ b/packages/command-modal/package.json
@@ -16,6 +16,16 @@
         "types": "./es/index.d.ts",
         "default": "./es/index.js"
       }
+    },
+    "./antd": {
+      "require": {
+        "types": "./lib/antd.d.ts",
+        "default": "./lib/antd.js"
+      },
+      "import": {
+        "types": "./es/antd.d.ts",
+        "default": "./es/antd.js"
+      }
     }
   },
   "sideEffects": false,

--- a/packages/command-modal/src/actions.tsx
+++ b/packages/command-modal/src/actions.tsx
@@ -17,10 +17,10 @@ import {
 } from "./context";
 import type {
   CommandModalAction,
-  CommandModalArgs,
   CommandModalCallbacks,
   CreateModalComponent,
   ModalInnerProps,
+  ResolveType,
 } from "./type";
 import { useModal } from "./useModal";
 
@@ -89,7 +89,7 @@ const settleAndDelete = (
  */
 export function showWithDispatch(
   modal: React.FC | string,
-  args: CommandModalArgs<React.FC> | undefined,
+  args: Record<string, unknown> | undefined,
   dispatch: Dispatch<CommandModalAction> | null
 ): Promise<unknown> {
   const modalId = getModalId(modal);
@@ -147,12 +147,12 @@ export function removeWithDispatch(
   // roundtrip because the component is still there).
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: C is constrained to any modal component; its concrete props are recovered via ModalInnerProps<C> at each call site.
-export function show<T, C extends CreateModalComponent<any>>(
+// biome-ignore lint/suspicious/noExplicitAny: C is constrained to any modal component; its concrete props are recovered via ModalInnerProps<C> and its resolve type via ResolveType<C>.
+export function show<C extends CreateModalComponent<any, any>>(
   modal: C,
   args?: Partial<ModalInnerProps<C>>
-): Promise<T>;
-export function show<T>(
+): Promise<ResolveType<C>>;
+export function show<T = unknown>(
   modal: string,
   args?: Record<string, unknown>
 ): Promise<T>;
@@ -182,7 +182,7 @@ export function show(
   // to the bare `React.FC` (= `FC<{}>`); the permissive `React.FC<any>` is.
   // biome-ignore lint/suspicious/noExplicitAny: see comment above — supertype of all show() overloads.
   modal: React.FC<any> | string,
-  args?: CommandModalArgs<React.FC>
+  args?: Record<string, unknown>
 ) {
   return showWithDispatch(modal, args, null);
 }
@@ -225,8 +225,10 @@ export const remove = (modal: string | CreateModalComponent): void => {
   removeWithDispatch(modal, null);
 };
 
-export const create = <P extends object>(Comp: React.ComponentType<P>) => {
-  const HocComp: CreateModalComponent<P> = ({
+export const create = <P extends object, R = unknown>(
+  Comp: React.ComponentType<P>
+): CreateModalComponent<P, R> => {
+  const HocComp: CreateModalComponent<P, R> = ({
     defaultVisible,
     keepMounted,
     id,

--- a/packages/command-modal/src/actions.tsx
+++ b/packages/command-modal/src/actions.tsx
@@ -194,7 +194,8 @@ export function hide<T, C>(modal: string | CreateModalComponent<C>): Promise<T>;
  *
  * Settlement contract:
  *  - Resolves with the value passed to `modal.resolveHide(value)` (typically
- *    from the modal component's `afterClose` hook).
+ *    from the adapter's post-close hook, e.g. `onOpenChangeComplete` for
+ *    shadcn/Base UI or `afterClose` for antd).
  *  - If the modal is removed or unregistered before `resolveHide` is called,
  *    the promise **resolves with `undefined`**.
  *  - Calling `hide()` also settles any outstanding `show()` promise with

--- a/packages/command-modal/src/antd.ts
+++ b/packages/command-modal/src/antd.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import type { ModalPropsAdapter } from "./type";
+
+/**
+ * The subset of Ant Design v6 `<Modal>` props this adapter drives. Hand-written
+ * (no `antd` import) so the package keeps its zero-dependency guarantee — antd's
+ * `open` / `onCancel` / `afterClose` are stable across v5→v6. Spread the rest
+ * (`title`, `onOk`, `width`, …) directly at the JSX site.
+ */
+export type AntdModalProps = {
+  open?: boolean;
+  onCancel?: () => void;
+  afterClose?: () => void;
+};
+
+/**
+ * Official adapter for Ant Design v6 `<Modal>`. Pass it to
+ * {@link createCommandModal} for a fully typed antd binding.
+ *
+ * @example
+ * ```tsx
+ * // lib/modal.ts
+ * import { createCommandModal } from '@easy-shadcn/command-modal';
+ * import { antdModalProps } from '@easy-shadcn/command-modal/antd';
+ *
+ * export const { Provider, useModal } = createCommandModal(antdModalProps);
+ * ```
+ */
+export const antdModalProps: ModalPropsAdapter<AntdModalProps> = (handler) => ({
+  open: handler.visible,
+  onCancel: () => {
+    handler.hide();
+  },
+  afterClose: () => {
+    handler.resolveHide();
+    if (!handler.keepMounted) {
+      handler.remove();
+    }
+  },
+});

--- a/packages/command-modal/src/antd.ts
+++ b/packages/command-modal/src/antd.ts
@@ -29,9 +29,8 @@ export type AntdModalProps = {
  */
 export const antdModalProps: ModalPropsAdapter<AntdModalProps> = (handler) => ({
   open: handler.visible,
-  onCancel: () => {
-    handler.hide();
-  },
+  // `handler.hide` is a stable callback; antd ignores its return value.
+  onCancel: handler.hide,
   afterClose: () => {
     handler.resolveHide();
     if (!handler.keepMounted) {

--- a/packages/command-modal/src/context.tsx
+++ b/packages/command-modal/src/context.tsx
@@ -297,12 +297,17 @@ export interface CommandModalProviderProps extends PropsWithChildren {
    *
    * @example
    * ```tsx
-   * import CommandModal, { antdModalAdapter } from '@easy-shadcn/command-modal';
+   * import { Provider } from '@easy-shadcn/command-modal';
+   * import { antdModalProps } from '@easy-shadcn/command-modal/antd';
    *
-   * <CommandModal.Provider config={{ modalPropsAdapter: antdModalAdapter }}>
+   * <Provider config={{ modalPropsAdapter: antdModalProps }}>
    *   <App />
-   * </CommandModal.Provider>
+   * </Provider>
    * ```
+   *
+   * For type-safe `modalProps` at the consumer, prefer
+   * `createCommandModal(antdModalProps)`, which returns a pre-bound `Provider`
+   * and a typed `useModal`.
    */
   config?: CommandModalConfig;
 }

--- a/packages/command-modal/src/create-command-modal.tsx
+++ b/packages/command-modal/src/create-command-modal.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import type { PropsWithChildren } from "react";
+import { Provider as BaseProvider } from "./context";
+import type {
+  CommandModalConfig,
+  ModalPropsAdapter,
+  UseModalReturn,
+} from "./type";
+import { useModal as baseUseModal } from "./useModal";
+
+/**
+ * Create a typed CommandModal binding for a specific adapter.
+ *
+ * Returns a `Provider` pre-bound to `adapter` and a `useModal` whose
+ * `modalProps` is statically typed as the adapter's return type — so antd / mui
+ * / any-library consumers get full type safety with no per-call casts. shadcn
+ * users don't need this: the package-root `useModal` is already shadcn-typed.
+ *
+ * Call this once at module scope (e.g. an app-local `lib/modal.ts` barrel).
+ * Calling it inside a render would mint a new `Provider` component identity each
+ * render and remount the whole modal tree.
+ *
+ * @example
+ * ```tsx
+ * // lib/modal.ts
+ * export const { Provider, useModal } = createCommandModal(antdModalProps);
+ * ```
+ */
+export function createCommandModal<TModalProps>(
+  adapter: ModalPropsAdapter<TModalProps>
+) {
+  // Stable, module-scoped config object. The base Provider already memoizes on
+  // the adapter identity, so a fresh wrapper render never invalidates
+  // downstream consumers.
+  const config: CommandModalConfig<TModalProps> = {
+    modalPropsAdapter: adapter,
+  };
+
+  const Provider = ({ children }: PropsWithChildren) => (
+    <BaseProvider config={config as CommandModalConfig}>
+      {children}
+    </BaseProvider>
+  );
+
+  // Type-only reskin: the SAME runtime hook, re-typed so `modalProps` is the
+  // adapter's `TModalProps`. The configured adapter is applied at runtime inside
+  // the base hook via the config context this Provider injects — so we must NOT
+  // re-wrap or re-invoke `adapter` here (that would double-run it and break the
+  // base hook's memoization).
+  const useModal = baseUseModal as unknown as UseModalReturn<TModalProps>;
+
+  return { Provider, useModal };
+}

--- a/packages/command-modal/src/index.ts
+++ b/packages/command-modal/src/index.ts
@@ -16,6 +16,7 @@ export {
   reducer,
   useCommandModalDispatch,
 } from "./context";
+export { createCommandModal } from "./create-command-modal";
 export type { ModalHolderActions } from "./holders";
 export { ModalDef } from "./holders";
 export type {
@@ -32,11 +33,13 @@ export { createModalProps, useModal, useModalHolder } from "./useModal";
 // Default export
 import { create, hide, register, remove, show, unregister } from "./actions";
 import { CommandModalContext, Provider, reducer } from "./context";
+import { createCommandModal } from "./create-command-modal";
 import { ModalDef } from "./holders";
 import { createModalProps, useModal, useModalHolder } from "./useModal";
 
 const CommandModal = {
   create,
+  createCommandModal,
   hide,
   register,
   remove,

--- a/packages/command-modal/src/type.ts
+++ b/packages/command-modal/src/type.ts
@@ -1,5 +1,3 @@
-import type { JSX } from "react";
-
 export interface CommandModalState {
   args?: Record<string, unknown>;
   delayVisible?: boolean;
@@ -139,25 +137,32 @@ export interface CommandModalHocProps {
 // The inner component's props (`T`) arrive at runtime via `show(id, args)`, not
 // at JSX-mount time. Anything passed where the HOC is mounted (`<Modal id=… />`)
 // only acts as a default, so `T` is partial there — `id` is the sole required prop.
-export type CreateModalComponent<T = object> = React.FC<
+export type CreateModalComponent<T = object, R = unknown> = React.FC<
   Partial<T> & CommandModalHocProps
->;
+> & {
+  /**
+   * Phantom marker carrying the modal's resolve (result) type. Exists only at
+   * the type level — never present at runtime. {@link ResolveType} reads it so
+   * `show(Comp)` returns `Promise<R>` without an explicit type argument.
+   */
+  readonly __resolveType?: R;
+};
 
-export type CommandModalArgs<T> = T extends
-  | keyof JSX.IntrinsicElements
-  | React.JSXElementConstructor<unknown>
-  ? React.ComponentProps<T>
-  : Record<string, unknown>;
+/**
+ * Extract the resolve (result) type `R` carried by a {@link CreateModalComponent}.
+ * Falls back to `unknown` for components that don't carry one.
+ */
+export type ResolveType<C> = C extends { __resolveType?: infer R }
+  ? R
+  : unknown;
 
 /**
  * The props a modal component accepts at `show()` / `register()` /
  * `useModal()` time: its own props minus the HOC-reserved keys
  * (`id` / `defaultVisible` / `keepMounted`), which the system injects.
  *
- * Unlike {@link CommandModalArgs} — whose conditional collapses to
- * `Record<string, unknown>` for any `React.FC` and therefore type-checks
- * nothing — this derives directly from the component, so a typed modal's
- * args are actually validated.
+ * Derives directly from the component, so a typed modal's args are actually
+ * validated at each `show()` / `register()` call site.
  */
 export type ModalInnerProps<
   // biome-ignore lint/suspicious/noExplicitAny: must accept any modal component (whose props carry a required `id`), matching CreateModalComponent<any>.

--- a/packages/command-modal/src/type.ts
+++ b/packages/command-modal/src/type.ts
@@ -39,7 +39,11 @@ export interface CommandModalCallbacks {
 export type ShadCNModalProps = {
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
-  afterClose?: () => void;
+  /**
+   * Base UI Dialog's real post-transition hook (fires on open AND close). The
+   * default adapter wires teardown here, guarded on `open === false`.
+   */
+  onOpenChangeComplete?: (open: boolean) => void;
 };
 
 /**
@@ -51,11 +55,11 @@ export type ShadCNModalProps = {
  * @returns Props object compatible with your modal library
  *
  * @example
- * // For shadcn/ui
+ * // For shadcn/ui (Base UI Dialog)
  * const shadcnAdapter: ModalPropsAdapter<ShadCNModalProps> = (handler) => ({
  *   open: handler.visible,
  *   onOpenChange: (open) => open ? handler.show() : handler.hide(),
- *   afterClose: () => { handler.resolveHide(); if (!handler.keepMounted) handler.remove(); }
+ *   onOpenChangeComplete: (open) => { if (!open) { handler.resolveHide(); if (!handler.keepMounted) handler.remove(); } }
  * });
  *
  * // For Ant Design

--- a/packages/command-modal/src/type.ts
+++ b/packages/command-modal/src/type.ts
@@ -168,3 +168,27 @@ export type ModalInnerProps<
   // biome-ignore lint/suspicious/noExplicitAny: must accept any modal component (whose props carry a required `id`), matching CreateModalComponent<any>.
   C extends React.ComponentType<any>,
 > = Omit<React.ComponentProps<C>, keyof CommandModalHocProps>;
+
+/**
+ * The overloaded return shape of {@link useModal}, parameterized over the
+ * `modalProps` type a given adapter produces. Single source of truth: the
+ * package-root `useModal` instantiates this with `ShadCNModalProps`, and the
+ * `createCommandModal` factory instantiates it with the adapter's `TModalProps`
+ * — so the two never drift.
+ */
+export type UseModalReturn<TModalProps> = {
+  (
+    modal?: string,
+    args?: Record<string, unknown>
+  ): CommandModalHandler & {
+    modalProps: TModalProps;
+  };
+  // biome-ignore lint/suspicious/noExplicitAny: C is any modal component; its props are recovered via ModalInnerProps<C> and its resolve type via ResolveType<C>.
+  <C extends React.FC<any>>(
+    modal: C,
+    args?: Partial<ModalInnerProps<C>>
+  ): Omit<CommandModalHandler, "show"> & {
+    show: (args?: Partial<ModalInnerProps<C>>) => Promise<ResolveType<C>>;
+    modalProps: TModalProps;
+  };
+};

--- a/packages/command-modal/src/useModal.tsx
+++ b/packages/command-modal/src/useModal.tsx
@@ -174,10 +174,14 @@ export function useModalHolder<T>(modal: string | CreateModalComponent<T>) {
 }
 
 /**
- * Helper function to create modal props for shadcn modal components.
- * This generates the standard props (open, onOpenChange, afterClose) from a modal handler.
+ * Helper function to create modal props for shadcn (Base UI) modal components.
+ * Generates the standard props (open, onOpenChange, onOpenChangeComplete) from a
+ * modal handler. Teardown is wired to Base UI's real `onOpenChangeComplete` hook
+ * (which fires on open AND close), guarded on `open === false`, so spreading the
+ * result onto a raw `<Dialog {...modalProps}>` removes the modal once its close
+ * animation finishes — no leak.
  * @param modal - The modal handler from useModal
- * @returns Props object compatible with shadcn modal components
+ * @returns Props object compatible with shadcn (Base UI) modal components
  */
 export const createModalProps = (
   modal: CommandModalHandler
@@ -190,7 +194,10 @@ export const createModalProps = (
       modal.hide();
     }
   },
-  afterClose: () => {
+  onOpenChangeComplete: (open) => {
+    if (open) {
+      return;
+    }
     modal.resolveHide();
     if (!modal.keepMounted) {
       modal.remove();

--- a/packages/command-modal/src/useModal.tsx
+++ b/packages/command-modal/src/useModal.tsx
@@ -26,27 +26,11 @@ import { ModalHolder, type ModalHolderActions } from "./holders";
 import type {
   CommandModalHandler,
   CreateModalComponent,
-  ModalInnerProps,
   ShadCNModalProps,
+  UseModalReturn,
 } from "./type";
 
-export function useModal(
-  modal?: string,
-  args?: Record<string, unknown>
-): CommandModalHandler & {
-  modalProps: ShadCNModalProps;
-};
-// biome-ignore lint/suspicious/noExplicitAny: C is any modal component; its concrete props are recovered via ModalInnerProps<C>.
-export function useModal<C extends React.FC<any>>(
-  modal: C,
-  args?: Partial<ModalInnerProps<C>>
-): Omit<CommandModalHandler, "show"> & {
-  show: (args?: Partial<ModalInnerProps<C>>) => Promise<unknown>;
-} & {
-  modalProps: ShadCNModalProps;
-};
-
-export function useModal(
+function useModalImpl(
   modal?: string | React.FC,
   args?: Record<string, unknown>
 ) {
@@ -167,6 +151,16 @@ export function useModal(
     config?.modalPropsAdapter,
   ]);
 }
+
+/**
+ * Package-root `useModal`: the default adapter is shadcn, so its `modalProps`
+ * is typed `ShadCNModalProps`. The runtime implementation is adapter-agnostic
+ * (it reads the configured adapter from context); the overload shape lives in
+ * the single-source {@link UseModalReturn}. The `createCommandModal` factory
+ * re-types this same implementation with the adapter's `TModalProps`.
+ */
+export const useModal =
+  useModalImpl as unknown as UseModalReturn<ShadCNModalProps>;
 
 export function useModalHolder<T>(modal: string | CreateModalComponent<T>) {
   const handler = useMemo(() => ({}) as ModalHolderActions, []);

--- a/packages/command-modal/test/antd.test.ts
+++ b/packages/command-modal/test/antd.test.ts
@@ -1,21 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { antdModalProps } from "../src/antd";
-import type { CommandModalHandler } from "../src/type";
-
-const makeHandler = (
-  overrides: Partial<CommandModalHandler> = {}
-): CommandModalHandler => ({
-  id: "test",
-  visible: false,
-  keepMounted: false,
-  show: vi.fn(),
-  hide: vi.fn(),
-  resolve: vi.fn(),
-  reject: vi.fn(),
-  remove: vi.fn(),
-  resolveHide: vi.fn(),
-  ...overrides,
-});
+import { makeHandler } from "./test-utils";
 
 describe("antdModalProps adapter (issue #71)", () => {
   it("maps the handler's visible state to antd's open", () => {

--- a/packages/command-modal/test/antd.test.ts
+++ b/packages/command-modal/test/antd.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import { antdModalProps } from "../src/antd";
+import type { CommandModalHandler } from "../src/type";
+
+const makeHandler = (
+  overrides: Partial<CommandModalHandler> = {}
+): CommandModalHandler => ({
+  id: "test",
+  visible: false,
+  keepMounted: false,
+  show: vi.fn(),
+  hide: vi.fn(),
+  resolve: vi.fn(),
+  reject: vi.fn(),
+  remove: vi.fn(),
+  resolveHide: vi.fn(),
+  ...overrides,
+});
+
+describe("antdModalProps adapter (issue #71)", () => {
+  it("maps the handler's visible state to antd's open", () => {
+    expect(antdModalProps(makeHandler({ visible: true })).open).toBe(true);
+    expect(antdModalProps(makeHandler({ visible: false })).open).toBe(false);
+  });
+
+  it("onCancel hides the modal", () => {
+    const hide = vi.fn();
+    antdModalProps(makeHandler({ hide })).onCancel?.();
+    expect(hide).toHaveBeenCalled();
+  });
+
+  it("afterClose resolves the hide and removes when not kept mounted", () => {
+    const resolveHide = vi.fn();
+    const remove = vi.fn();
+    antdModalProps(makeHandler({ resolveHide, remove })).afterClose?.();
+    expect(resolveHide).toHaveBeenCalled();
+    expect(remove).toHaveBeenCalled();
+  });
+
+  it("afterClose resolves the hide but keeps the modal when keepMounted", () => {
+    const resolveHide = vi.fn();
+    const remove = vi.fn();
+    antdModalProps(
+      makeHandler({ keepMounted: true, resolveHide, remove })
+    ).afterClose?.();
+    expect(resolveHide).toHaveBeenCalled();
+    expect(remove).not.toHaveBeenCalled();
+  });
+});

--- a/packages/command-modal/test/factory.test-d.ts
+++ b/packages/command-modal/test/factory.test-d.ts
@@ -1,0 +1,37 @@
+import { describe, expectTypeOf, it } from "vitest";
+import { createCommandModal } from "../src/create-command-modal";
+import type { CommandModalHandler, ShadCNModalProps } from "../src/type";
+import { useModal as rootUseModal } from "../src/useModal";
+
+type AntdLikeProps = {
+  open: boolean;
+  onCancel: () => void;
+};
+
+const antdLikeAdapter = (handler: CommandModalHandler): AntdLikeProps => ({
+  open: handler.visible,
+  onCancel: () => handler.hide(),
+});
+
+describe("createCommandModal factory (issue #72)", () => {
+  it("types modalProps as the adapter's return type", () => {
+    const { useModal } = createCommandModal(antdLikeAdapter);
+    const Modal = (() => null) as React.FC<{ name: string }>;
+    expectTypeOf(useModal(Modal).modalProps).toEqualTypeOf<AntdLikeProps>();
+  });
+
+  it("returns only { Provider, useModal }", () => {
+    const api = createCommandModal(antdLikeAdapter);
+    expectTypeOf(api).toEqualTypeOf<{
+      Provider: typeof api.Provider;
+      useModal: typeof api.useModal;
+    }>();
+  });
+
+  it("root useModal still types modalProps as ShadCNModalProps", () => {
+    const Modal = (() => null) as React.FC<{ name: string }>;
+    expectTypeOf(
+      rootUseModal(Modal).modalProps
+    ).toEqualTypeOf<ShadCNModalProps>();
+  });
+});

--- a/packages/command-modal/test/factory.test.tsx
+++ b/packages/command-modal/test/factory.test.tsx
@@ -1,0 +1,116 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { create, show } from "../src/actions";
+import { createCommandModal } from "../src/create-command-modal";
+import type { CommandModalHandler } from "../src/type";
+
+describe("createCommandModal factory (issue #72)", () => {
+  it("injects the adapter, so modalProps comes from it (not the shadcn default)", async () => {
+    const adapter = (handler: CommandModalHandler) => ({
+      open: handler.visible,
+      onCancel: () => handler.hide(),
+      marker: "factory-adapter" as const,
+    });
+    const { Provider, useModal } = createCommandModal(adapter);
+
+    let captured: ReturnType<typeof adapter> | undefined;
+    const TestModal = create(() => {
+      const modal = useModal();
+      captured = modal.modalProps;
+      return modal.visible ? <div data-testid="m">content</div> : null;
+    });
+
+    render(
+      <Provider>
+        <TestModal id="factory-marker" />
+      </Provider>
+    );
+    act(() => {
+      show("factory-marker");
+    });
+
+    await waitFor(() => {
+      expect(captured?.marker).toBe("factory-adapter");
+      expect(captured?.open).toBe(true);
+    });
+  });
+
+  it("wires adapter callbacks to handler verbs (onCancel hides the modal)", async () => {
+    const adapter = (handler: CommandModalHandler) => ({
+      open: handler.visible,
+      onCancel: () => handler.hide(),
+    });
+    const { Provider, useModal } = createCommandModal(adapter);
+
+    let captured: ReturnType<typeof adapter> | undefined;
+    const TestModal = create(() => {
+      const modal = useModal();
+      captured = modal.modalProps;
+      return modal.visible ? (
+        <div data-testid="open">open</div>
+      ) : (
+        <div data-testid="closed">closed</div>
+      );
+    });
+
+    const { getByTestId } = render(
+      <Provider>
+        <TestModal id="factory-cancel" />
+      </Provider>
+    );
+    act(() => {
+      show("factory-cancel");
+    });
+    await waitFor(() => getByTestId("open"));
+
+    act(() => {
+      captured?.onCancel();
+    });
+    await waitFor(() => getByTestId("closed"));
+  });
+
+  it("keeps modalProps referentially stable across a state-only re-render", async () => {
+    const adapter = (handler: CommandModalHandler) => ({
+      open: handler.visible,
+      onCancel: () => handler.hide(),
+    });
+    const { Provider, useModal } = createCommandModal(adapter);
+
+    let captured: unknown;
+    let renderCount = 0;
+    let forceRerender: () => void = () => {
+      // assigned on first render
+    };
+    const TestModal = create(() => {
+      const modal = useModal();
+      const [, setTick] = useState(0);
+      forceRerender = () => setTick((t) => t + 1);
+      renderCount += 1;
+      captured = modal.modalProps;
+      return modal.visible ? <div data-testid="m">m</div> : null;
+    });
+
+    render(
+      <Provider>
+        <TestModal id="factory-memo" />
+      </Provider>
+    );
+    act(() => {
+      show("factory-memo");
+    });
+    await waitFor(() => expect(captured).toBeDefined());
+
+    const snapshot = captured;
+    const countBefore = renderCount;
+    act(() => {
+      forceRerender();
+    });
+    await waitFor(() => expect(renderCount).toBeGreaterThan(countBefore));
+
+    // modalProps must be the SAME reference across a state-only re-render. A
+    // naive `{ ...m, modalProps: adapter(m) }` factory would mint a fresh object
+    // every render and break this — and downstream memoization with it.
+    expect(captured).toBe(snapshot);
+  });
+});

--- a/packages/command-modal/test/modalProps.test.tsx
+++ b/packages/command-modal/test/modalProps.test.tsx
@@ -11,6 +11,7 @@ import { hideModalCallbacks } from "../src/constants";
 import { Provider } from "../src/context";
 import type { CommandModalHandler } from "../src/type";
 import { createModalProps, useModal } from "../src/useModal";
+import { makeHandler } from "./test-utils";
 
 describe("modalProps", () => {
   describe("open property", () => {
@@ -94,21 +95,6 @@ describe("modalProps", () => {
   });
 
   describe("onOpenChangeComplete callback", () => {
-    const makeHandler = (
-      overrides: Partial<CommandModalHandler> = {}
-    ): CommandModalHandler => ({
-      id: "test",
-      visible: false,
-      keepMounted: false,
-      show: vi.fn(),
-      hide: vi.fn(),
-      resolve: vi.fn(),
-      reject: vi.fn(),
-      remove: vi.fn(),
-      resolveHide: vi.fn(),
-      ...overrides,
-    });
-
     it("should call resolveHide() when onOpenChangeComplete(false) is called", () => {
       const resolveHideMock = vi.fn();
       const result = createModalProps(

--- a/packages/command-modal/test/modalProps.test.tsx
+++ b/packages/command-modal/test/modalProps.test.tsx
@@ -9,44 +9,19 @@ import { describe, expect, it, vi } from "vitest";
 import { create, hide, show } from "../src/actions";
 import { hideModalCallbacks } from "../src/constants";
 import { Provider } from "../src/context";
-import type { CommandModalHandler } from "../src/type";
 import { createModalProps, useModal } from "../src/useModal";
 import { makeHandler } from "./test-utils";
 
 describe("modalProps", () => {
   describe("open property", () => {
     it("should return open=true when modal is visible", () => {
-      const mockHandler: CommandModalHandler = {
-        id: "test",
-        visible: true,
-        keepMounted: false,
-        show: vi.fn(),
-        hide: vi.fn(),
-        resolve: vi.fn(),
-        reject: vi.fn(),
-        remove: vi.fn(),
-        resolveHide: vi.fn(),
-      };
-
-      const result = createModalProps(mockHandler);
+      const result = createModalProps(makeHandler({ visible: true }));
 
       expect(result.open).toBe(true);
     });
 
     it("should return open=false when modal is not visible", () => {
-      const mockHandler: CommandModalHandler = {
-        id: "test",
-        visible: false,
-        keepMounted: false,
-        show: vi.fn(),
-        hide: vi.fn(),
-        resolve: vi.fn(),
-        reject: vi.fn(),
-        remove: vi.fn(),
-        resolveHide: vi.fn(),
-      };
-
-      const result = createModalProps(mockHandler);
+      const result = createModalProps(makeHandler({ visible: false }));
 
       expect(result.open).toBe(false);
     });
@@ -55,19 +30,8 @@ describe("modalProps", () => {
   describe("onOpenChange callback", () => {
     it("should call show() when onOpenChange(true) is called", () => {
       const showMock = vi.fn();
-      const mockHandler: CommandModalHandler = {
-        id: "test",
-        visible: false,
-        keepMounted: false,
-        show: showMock,
-        hide: vi.fn(),
-        resolve: vi.fn(),
-        reject: vi.fn(),
-        remove: vi.fn(),
-        resolveHide: vi.fn(),
-      };
+      const result = createModalProps(makeHandler({ show: showMock }));
 
-      const result = createModalProps(mockHandler);
       result.onOpenChange?.(true);
 
       expect(showMock).toHaveBeenCalled();
@@ -75,19 +39,10 @@ describe("modalProps", () => {
 
     it("should call hide() when onOpenChange(false) is called", () => {
       const hideMock = vi.fn();
-      const mockHandler: CommandModalHandler = {
-        id: "test",
-        visible: true,
-        keepMounted: false,
-        show: vi.fn(),
-        hide: hideMock,
-        resolve: vi.fn(),
-        reject: vi.fn(),
-        remove: vi.fn(),
-        resolveHide: vi.fn(),
-      };
+      const result = createModalProps(
+        makeHandler({ visible: true, hide: hideMock })
+      );
 
-      const result = createModalProps(mockHandler);
       result.onOpenChange?.(false);
 
       expect(hideMock).toHaveBeenCalled();
@@ -197,6 +152,7 @@ describe("modalProps", () => {
                 props.onOpenChange?.(false);
                 props.onOpenChangeComplete?.(false);
               }}
+              type="button"
             >
               Close
             </button>
@@ -255,9 +211,10 @@ describe("modalProps", () => {
         }
         return (
           <div data-testid="dialog-root">
-            <div
+            <button
               data-testid="dialog-overlay"
               onClick={() => onOpenChange?.(false)}
+              type="button"
             />
             <div data-testid="dialog-content">{children}</div>
           </div>

--- a/packages/command-modal/test/modalProps.test.tsx
+++ b/packages/command-modal/test/modalProps.test.tsx
@@ -5,10 +5,12 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import { useContext } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { create, hide, show } from "../src/actions";
 import { hideModalCallbacks } from "../src/constants";
-import { Provider } from "../src/context";
+import { CommandModalContext, Provider } from "../src/context";
+import type { ShadCNModalProps } from "../src/type";
 import { createModalProps, useModal } from "../src/useModal";
 import { makeHandler } from "./test-utils";
 
@@ -252,6 +254,77 @@ describe("modalProps", () => {
 
       await waitFor(() => {
         expect(screen.queryByTestId("dialog-root")).not.toBeInTheDocument();
+      });
+    });
+
+    it("removes the reducer entry end-to-end when the dialog fires onOpenChangeComplete (no leak)", async () => {
+      // The precise leak signal lives in the reducer, not the promise stores:
+      // hide() keeps the entry as `{ visible: false }`, only remove() deletes
+      // it. A probe reads the reducer state so the test can tell them apart.
+      let reducerState: Record<string, { visible?: boolean } | undefined> = {};
+      const Probe: React.FC = () => {
+        reducerState = useContext(CommandModalContext);
+        return null;
+      };
+
+      // A Base-UI-shaped dialog: it reads `onOpenChangeComplete` and fires it
+      // once its close transition finishes. If the adapter ever stops emitting
+      // that prop (e.g. reverting to antd's `afterClose`), this dialog gets
+      // `undefined` here, only `onOpenChange → hide()` runs, and the reducer
+      // entry lingers `visible:false` forever — the leak this guards against.
+      const Dialog: React.FC<
+        ShadCNModalProps & { children?: React.ReactNode }
+      > = ({ open, onOpenChange, onOpenChangeComplete, children }) => {
+        if (!open) {
+          return null;
+        }
+        return (
+          <div data-testid="leak-dialog">
+            {children}
+            <button
+              data-testid="leak-close"
+              onClick={() => {
+                onOpenChange?.(false);
+                onOpenChangeComplete?.(false);
+              }}
+              type="button"
+            />
+          </div>
+        );
+      };
+
+      const TestModal = create(() => {
+        const modal = useModal();
+        return (
+          <Dialog {...modal.modalProps}>
+            <div data-testid="leak-content">Content</div>
+          </Dialog>
+        );
+      });
+
+      render(
+        <Provider>
+          <Probe />
+          <TestModal id="leak-test" />
+        </Provider>
+      );
+
+      act(() => {
+        show("leak-test");
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("leak-dialog")).toBeInTheDocument();
+        expect(reducerState["leak-test"]?.visible).toBe(true);
+      });
+
+      fireEvent.click(screen.getByTestId("leak-close"));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("leak-dialog")).not.toBeInTheDocument();
+        // remove() must delete the reducer entry. With the old afterClose
+        // wiring a raw Dialog only fired hide(), leaving the entry behind.
+        expect(reducerState["leak-test"]).toBeUndefined();
       });
     });
   });

--- a/packages/command-modal/test/modalProps.test.tsx
+++ b/packages/command-modal/test/modalProps.test.tsx
@@ -93,64 +93,63 @@ describe("modalProps", () => {
     });
   });
 
-  describe("afterClose callback", () => {
-    it("should call resolveHide() when afterClose is called", () => {
-      const resolveHideMock = vi.fn();
-      const mockHandler: CommandModalHandler = {
-        id: "test",
-        visible: false,
-        keepMounted: false,
-        show: vi.fn(),
-        hide: vi.fn(),
-        resolve: vi.fn(),
-        reject: vi.fn(),
-        remove: vi.fn(),
-        resolveHide: resolveHideMock,
-      };
+  describe("onOpenChangeComplete callback", () => {
+    const makeHandler = (
+      overrides: Partial<CommandModalHandler> = {}
+    ): CommandModalHandler => ({
+      id: "test",
+      visible: false,
+      keepMounted: false,
+      show: vi.fn(),
+      hide: vi.fn(),
+      resolve: vi.fn(),
+      reject: vi.fn(),
+      remove: vi.fn(),
+      resolveHide: vi.fn(),
+      ...overrides,
+    });
 
-      const result = createModalProps(mockHandler);
-      result.afterClose?.();
+    it("should call resolveHide() when onOpenChangeComplete(false) is called", () => {
+      const resolveHideMock = vi.fn();
+      const result = createModalProps(
+        makeHandler({ resolveHide: resolveHideMock })
+      );
+
+      result.onOpenChangeComplete?.(false);
 
       expect(resolveHideMock).toHaveBeenCalled();
     });
 
-    it("should call remove() when afterClose is called and keepMounted is false", () => {
+    it("should call remove() on close-complete when keepMounted is false", () => {
       const removeMock = vi.fn();
-      const mockHandler: CommandModalHandler = {
-        id: "test",
-        visible: false,
-        keepMounted: false,
-        show: vi.fn(),
-        hide: vi.fn(),
-        resolve: vi.fn(),
-        reject: vi.fn(),
-        remove: removeMock,
-        resolveHide: vi.fn(),
-      };
+      const result = createModalProps(makeHandler({ remove: removeMock }));
 
-      const result = createModalProps(mockHandler);
-      result.afterClose?.();
+      result.onOpenChangeComplete?.(false);
 
       expect(removeMock).toHaveBeenCalled();
     });
 
-    it("should NOT call remove() when afterClose is called and keepMounted is true", () => {
+    it("should NOT call remove() on close-complete when keepMounted is true", () => {
       const removeMock = vi.fn();
-      const mockHandler: CommandModalHandler = {
-        id: "test",
-        visible: false,
-        keepMounted: true,
-        show: vi.fn(),
-        hide: vi.fn(),
-        resolve: vi.fn(),
-        reject: vi.fn(),
-        remove: removeMock,
-        resolveHide: vi.fn(),
-      };
+      const result = createModalProps(
+        makeHandler({ keepMounted: true, remove: removeMock })
+      );
 
-      const result = createModalProps(mockHandler);
-      result.afterClose?.();
+      result.onOpenChangeComplete?.(false);
 
+      expect(removeMock).not.toHaveBeenCalled();
+    });
+
+    it("should be a no-op on open-complete — Base UI also fires this on open", () => {
+      const resolveHideMock = vi.fn();
+      const removeMock = vi.fn();
+      const result = createModalProps(
+        makeHandler({ resolveHide: resolveHideMock, remove: removeMock })
+      );
+
+      result.onOpenChangeComplete?.(true);
+
+      expect(resolveHideMock).not.toHaveBeenCalled();
       expect(removeMock).not.toHaveBeenCalled();
     });
   });
@@ -210,7 +209,7 @@ describe("modalProps", () => {
               data-testid="close-btn"
               onClick={() => {
                 props.onOpenChange?.(false);
-                props.afterClose?.();
+                props.onOpenChangeComplete?.(false);
               }}
             >
               Close

--- a/packages/command-modal/test/resolve-type.test-d.ts
+++ b/packages/command-modal/test/resolve-type.test-d.ts
@@ -1,0 +1,39 @@
+import { describe, expectTypeOf, it } from "vitest";
+import { create, show } from "../src/actions";
+
+type User = { id: string; name: string };
+
+describe("resolve type carried on create<Props, Result> (issue #69)", () => {
+  it("show(create<Props, Result>(Comp)) resolves with Result", () => {
+    const EditUser = create<{ userId: string }, User>(() => null);
+    expectTypeOf(show(EditUser)).toEqualTypeOf<Promise<User>>();
+  });
+
+  it("checks show args against Props (the __resolveType brand must not erase prop inference)", () => {
+    const EditUser = create<{ userId: string }, User>(() => null);
+    // Valid args accepted.
+    show(EditUser, { userId: "x" });
+    // @ts-expect-error - userId must be a string
+    show(EditUser, { userId: 123 });
+    // @ts-expect-error - unknown prop rejected
+    show(EditUser, { nope: true });
+  });
+
+  it("resolves with Promise<unknown> when Result is omitted, args still checked", () => {
+    const FormModal = create<{ userId: string }>(() => null);
+    expectTypeOf(show(FormModal)).toEqualTypeOf<Promise<unknown>>();
+    // Args are still validated even without a Result type.
+    // @ts-expect-error - userId must be a string
+    show(FormModal, { userId: 123 });
+  });
+
+  it("resolves with a primitive Result (confirm-dialog shape)", () => {
+    const ConfirmModal = create<Record<never, never>, boolean>(() => null);
+    expectTypeOf(show(ConfirmModal)).toEqualTypeOf<Promise<boolean>>();
+  });
+
+  it("string-id path keeps the explicit Result type argument", () => {
+    expectTypeOf(show<User>("user-modal")).toEqualTypeOf<Promise<User>>();
+    expectTypeOf(show("user-modal")).toEqualTypeOf<Promise<unknown>>();
+  });
+});

--- a/packages/command-modal/test/test-utils.tsx
+++ b/packages/command-modal/test/test-utils.tsx
@@ -40,12 +40,18 @@ export const makeHandler = (
  * Should be called in beforeEach to ensure test isolation.
  */
 export const resetRegistry = () => {
-  Object.keys(MODAL_REGISTRY).forEach((key) => delete MODAL_REGISTRY[key]);
-  Object.keys(ALREADY_MOUNTED).forEach((key) => delete ALREADY_MOUNTED[key]);
-  Object.keys(modalCallbacks).forEach((key) => delete modalCallbacks[key]);
-  Object.keys(hideModalCallbacks).forEach(
-    (key) => delete hideModalCallbacks[key]
-  );
+  for (const key of Object.keys(MODAL_REGISTRY)) {
+    delete MODAL_REGISTRY[key];
+  }
+  for (const key of Object.keys(ALREADY_MOUNTED)) {
+    delete ALREADY_MOUNTED[key];
+  }
+  for (const key of Object.keys(modalCallbacks)) {
+    delete modalCallbacks[key];
+  }
+  for (const key of Object.keys(hideModalCallbacks)) {
+    delete hideModalCallbacks[key];
+  }
   __resetMultipleProvidersWarning();
   __resetDispatchStack();
 };
@@ -73,6 +79,7 @@ export const MockDialog: React.FC<{
           // Simulate Base UI firing the post-close-transition hook.
           onOpenChangeComplete?.(false);
         }}
+        type="button"
       >
         Close
       </button>
@@ -103,6 +110,7 @@ export const createTestModal = (testId: string) => {
             modal.resolve(onResolve ? onResolve("resolved") : "resolved");
             modal.hide();
           }}
+          type="button"
         >
           Resolve
         </button>
@@ -112,6 +120,7 @@ export const createTestModal = (testId: string) => {
             modal.reject(onReject ? onReject("rejected") : "rejected");
             modal.hide();
           }}
+          type="button"
         >
           Reject
         </button>

--- a/packages/command-modal/test/test-utils.tsx
+++ b/packages/command-modal/test/test-utils.tsx
@@ -35,10 +35,10 @@ export const resetRegistry = () => {
 export const MockDialog: React.FC<{
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
-  afterClose?: () => void;
+  onOpenChangeComplete?: (open: boolean) => void;
   children?: ReactNode;
   testId?: string;
-}> = ({ open, onOpenChange, afterClose, children, testId }) => {
+}> = ({ open, onOpenChange, onOpenChangeComplete, children, testId }) => {
   if (!open) {
     return null;
   }
@@ -49,7 +49,8 @@ export const MockDialog: React.FC<{
         data-testid="close-btn"
         onClick={() => {
           onOpenChange?.(false);
-          afterClose?.();
+          // Simulate Base UI firing the post-close-transition hook.
+          onOpenChangeComplete?.(false);
         }}
       >
         Close
@@ -69,8 +70,8 @@ export const createTestModal = (testId: string) => {
     const modal = useModal();
     return (
       <MockDialog
-        afterClose={modal.modalProps.afterClose}
         onOpenChange={modal.modalProps.onOpenChange}
+        onOpenChangeComplete={modal.modalProps.onOpenChangeComplete}
         open={modal.visible}
         testId={testId}
       >

--- a/packages/command-modal/test/test-utils.tsx
+++ b/packages/command-modal/test/test-utils.tsx
@@ -1,5 +1,6 @@
 import { type RenderOptions, render } from "@testing-library/react";
 import type { ReactElement, ReactNode } from "react";
+import { vi } from "vitest";
 import { create } from "../src/actions";
 import {
   ALREADY_MOUNTED,
@@ -12,7 +13,27 @@ import {
   __resetMultipleProvidersWarning,
   Provider,
 } from "../src/context";
+import type { CommandModalHandler } from "../src/type";
 import { useModal } from "../src/useModal";
+
+/**
+ * Build a fully-stubbed `CommandModalHandler` for unit-testing adapters in
+ * isolation. Every method is a `vi.fn()`; override any field as needed.
+ */
+export const makeHandler = (
+  overrides: Partial<CommandModalHandler> = {}
+): CommandModalHandler => ({
+  id: "test",
+  visible: false,
+  keepMounted: false,
+  show: vi.fn(),
+  hide: vi.fn(),
+  resolve: vi.fn(),
+  reject: vi.fn(),
+  remove: vi.fn(),
+  resolveHide: vi.fn(),
+  ...overrides,
+});
 
 /**
  * Reset all global registries and callbacks.

--- a/packages/command-modal/test/useModal.test.tsx
+++ b/packages/command-modal/test/useModal.test.tsx
@@ -427,7 +427,7 @@ describe("useModal", () => {
         expect(capturedModalProps).toBeDefined();
         expect(capturedModalProps.open).toBe(true);
         expect(typeof capturedModalProps.onOpenChange).toBe("function");
-        expect(typeof capturedModalProps.afterClose).toBe("function");
+        expect(typeof capturedModalProps.onOpenChangeComplete).toBe("function");
       });
     });
   });

--- a/packages/command-modal/tsconfig.test.json
+++ b/packages/command-modal/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "declaration": false,
+    "emitDeclarationOnly": false
+  },
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/packages/command-modal/vitest.config.ts
+++ b/packages/command-modal/vitest.config.ts
@@ -7,6 +7,10 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./test/setup.ts"],
     globals: true,
+    typecheck: {
+      tsconfig: "./tsconfig.test.json",
+      include: ["test/**/*.test-d.ts"],
+    },
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],

--- a/registry/ui/modal/alert-modal-helper.tsx
+++ b/registry/ui/modal/alert-modal-helper.tsx
@@ -22,16 +22,18 @@ const alert = (
       <AlertModal
         {...props}
         {...modalProps}
-        afterClose={() => {
-          props.afterClose?.();
-          modalProps.afterClose?.();
-          // Each call creates a fresh component — drop its registry entry
-          // once fully closed, or long-lived apps leak one entry per call.
-          CommandModal.unregister(id);
-        }}
         onConfirm={async () => {
           await props.onConfirm?.();
           resolve(true);
+        }}
+        onOpenChangeComplete={(o) => {
+          props.onOpenChangeComplete?.(o);
+          modalProps.onOpenChangeComplete?.(o);
+          // Each call creates a fresh component — drop its registry entry
+          // once fully closed, or long-lived apps leak one entry per call.
+          if (!o) {
+            CommandModal.unregister(id);
+          }
         }}
         showCancel={false}
       />
@@ -59,11 +61,6 @@ const confirm = (
       <AlertModal
         {...props}
         {...modalProps}
-        afterClose={() => {
-          props.afterClose?.();
-          modalProps.afterClose?.();
-          CommandModal.unregister(id);
-        }}
         onCancel={async () => {
           await props.onCancel?.();
           resolve(false);
@@ -71,6 +68,13 @@ const confirm = (
         onConfirm={async () => {
           await props.onConfirm?.();
           resolve(true);
+        }}
+        onOpenChangeComplete={(o) => {
+          props.onOpenChangeComplete?.(o);
+          modalProps.onOpenChangeComplete?.(o);
+          if (!o) {
+            CommandModal.unregister(id);
+          }
         }}
       />
     );

--- a/registry/ui/modal/alert-modal-helper.tsx
+++ b/registry/ui/modal/alert-modal-helper.tsx
@@ -5,6 +5,24 @@ import { AlertModal, type AlertModalProps } from "./alert-modal";
 
 type AlertHelperProps = Omit<AlertModalProps, "open" | "onOpenChange">;
 
+type CloseCompleteHook = ((open: boolean) => void) | undefined;
+
+/**
+ * Compose the caller's and command-modal's `onOpenChangeComplete` hooks, then
+ * unregister the one-shot modal once it has fully closed. Each helper call
+ * creates a fresh component — without this, long-lived apps leak one registry
+ * entry per call.
+ */
+const chainCloseAndUnregister =
+  (id: string, callerHook: CloseCompleteHook, modalHook: CloseCompleteHook) =>
+  (open: boolean) => {
+    callerHook?.(open);
+    modalHook?.(open);
+    if (!open) {
+      CommandModal.unregister(id);
+    }
+  };
+
 /**
  * Promise-style alert: a single OK button.
  * Resolves once the user confirms or dismisses the dialog.
@@ -26,15 +44,11 @@ const alert = (
           await props.onConfirm?.();
           resolve(true);
         }}
-        onOpenChangeComplete={(o) => {
-          props.onOpenChangeComplete?.(o);
-          modalProps.onOpenChangeComplete?.(o);
-          // Each call creates a fresh component — drop its registry entry
-          // once fully closed, or long-lived apps leak one entry per call.
-          if (!o) {
-            CommandModal.unregister(id);
-          }
-        }}
+        onOpenChangeComplete={chainCloseAndUnregister(
+          id,
+          props.onOpenChangeComplete,
+          modalProps.onOpenChangeComplete
+        )}
         showCancel={false}
       />
     );
@@ -69,13 +83,11 @@ const confirm = (
           await props.onConfirm?.();
           resolve(true);
         }}
-        onOpenChangeComplete={(o) => {
-          props.onOpenChangeComplete?.(o);
-          modalProps.onOpenChangeComplete?.(o);
-          if (!o) {
-            CommandModal.unregister(id);
-          }
-        }}
+        onOpenChangeComplete={chainCloseAndUnregister(
+          id,
+          props.onOpenChangeComplete,
+          modalProps.onOpenChangeComplete
+        )}
       />
     );
   });

--- a/registry/ui/modal/alert-modal.tsx
+++ b/registry/ui/modal/alert-modal.tsx
@@ -21,7 +21,12 @@ import { cn } from "@/lib/utils";
 import { AsyncButton } from "../async-button";
 
 export interface AlertModalProps {
-  afterClose?: () => void;
+  /**
+   * Base UI AlertDialog's post-transition hook — fires after the open/close
+   * animation completes (with the resulting `open` state). Forwarded straight
+   * to the underlying AlertDialog. command-modal's adapter wires teardown here.
+   */
+  onOpenChangeComplete?: (open: boolean) => void;
   /**
    * Extra props for the cancel AsyncButton. Passing `onClick` replaces the
    * built-in close handler — prefer `onCancel`.
@@ -86,7 +91,7 @@ export const AlertModal: React.FC<AlertModalProps> = ({
   onConfirm,
   confirmProps,
   showCancel = true,
-  afterClose,
+  onOpenChangeComplete,
 }) => {
   const [internalOpen, setInternalOpen] = useState(defaultOpen ?? false);
   const currentOpen = open === undefined ? internalOpen : open;
@@ -103,11 +108,7 @@ export const AlertModal: React.FC<AlertModalProps> = ({
   return (
     <AlertDialog
       onOpenChange={handleOpenChange}
-      onOpenChangeComplete={(o) => {
-        if (!o) {
-          afterClose?.();
-        }
-      }}
+      onOpenChangeComplete={onOpenChangeComplete}
       open={currentOpen}
     >
       {trigger && <AlertDialogTrigger render={trigger} />}

--- a/registry/ui/modal/modal.test.tsx
+++ b/registry/ui/modal/modal.test.tsx
@@ -206,20 +206,23 @@ describe("AlertModal helpers", () => {
     await expect(result!).resolves.toBeUndefined();
   });
 
-  it("chains the caller's afterClose instead of overwriting it", async () => {
-    const afterClose = vi.fn();
+  it("chains the caller's onOpenChangeComplete instead of overwriting it", async () => {
+    const onOpenChangeComplete = vi.fn();
     render(<CommandModal.Provider>{null}</CommandModal.Provider>);
 
     let result: Promise<void>;
     act(() => {
-      result = AlertModalHelper.alert({ afterClose, title: "Saved" });
+      result = AlertModalHelper.alert({ onOpenChangeComplete, title: "Saved" });
     });
 
     fireEvent.click(await screen.findByRole("button", { name: "OK" }));
     await result!;
 
+    // Base UI's hook fires on open AND close; the caller's callback must be
+    // chained (not overwritten by the helper's unregister handler) and receive
+    // the close-complete signal.
     await waitFor(() => {
-      expect(afterClose).toHaveBeenCalledTimes(1);
+      expect(onOpenChangeComplete).toHaveBeenCalledWith(false);
     });
   });
 });

--- a/registry/ui/modal/modal.tsx
+++ b/registry/ui/modal/modal.tsx
@@ -21,7 +21,12 @@ import { cn } from "@/lib/utils";
 import { AsyncButton } from "../async-button";
 
 export interface ModalProps {
-  afterClose?: () => void;
+  /**
+   * Base UI Dialog's post-transition hook — fires after the open/close
+   * animation completes (with the resulting `open` state). Forwarded straight
+   * to the underlying Dialog. command-modal's adapter wires teardown here.
+   */
+  onOpenChangeComplete?: (open: boolean) => void;
   /**
    * Extra props for the default footer's cancel AsyncButton. Passing
    * `onClick` replaces the built-in close handler — prefer `onCancel`.
@@ -90,7 +95,7 @@ export const Modal: React.FC<ModalProps> = ({
   onConfirm,
   trigger,
   showCloseButton = true,
-  afterClose,
+  onOpenChangeComplete,
 }) => {
   const [internalOpen, setInternalOpen] = useState(defaultOpen ?? false);
   const currentOpen = open === undefined ? internalOpen : open;
@@ -144,11 +149,7 @@ export const Modal: React.FC<ModalProps> = ({
     <Dialog
       disablePointerDismissal={disablePointerDismissal}
       onOpenChange={handleOpenChange}
-      onOpenChangeComplete={(o) => {
-        if (!o) {
-          afterClose?.();
-        }
-      }}
+      onOpenChangeComplete={onOpenChangeComplete}
       open={currentOpen}
     >
       {trigger && <DialogTrigger render={trigger} />}


### PR DESCRIPTION
Makes `@easy-shadcn/command-modal` actually deliver its two headline promises — "Type-safe" and "works with any modal UI library through adapters" — and fixes a real leak in the flagship shadcn example. Spec: `docs/specs/2026-06-29-command-modal-type-safety.md`; decisions in `docs/adr/0001`, `0002`.

## What's in here

Five tracer-bullet slices, one commit each:

- **#69 — resolve type on `create<Props, Result>`.** A type-level phantom brand carries the resolve type; `show(Comp, args)` now infers both args and `Promise<Result>` with **zero** explicit type arguments, fixing the old `show<T>(Comp)` overload degradation. Deletes the dead `CommandModalArgs` type.
- **#72 — `createCommandModal(adapter)` factory.** Returns a config-bound `{ Provider, useModal }` whose `modalProps` is statically typed as the adapter's return type — antd/any-library consumers get type-safe `modalProps` with no casts. It's a type-only reskin of the same runtime hook (no double adapter call / no broken memo, guarded by a referential-stability test). Root + factory `useModal` share a single `UseModalReturn<T>` to prevent overload drift.
- **#70 — shadcn adapter emits Base UI's real hook.** ⚠️ **Breaking.** `createModalProps` / `ShadCNModalProps` swap the antd-ism `afterClose` for Base UI's real `onOpenChangeComplete` (guarded on close), so a raw `<Dialog {...modal.modalProps}>` removes the modal once its close animation finishes instead of leaking. The registry `Modal`/`AlertModal` wrappers are aligned to the primitive too (AGENTS.md "align naming with primitive").
- **#71 — official antd v6 adapter.** `antdModalProps` + a hand-written, antd-import-free `AntdModalProps` ship at `@easy-shadcn/command-modal/antd`. Core stays zero-dependency; verified the subpath resolves at runtime and under bundler + node16 type resolution.
- **#73 — docs.** Real docs link (was a `your-docs-url.com` placeholder), antd recipe (app-local barrel + `no-restricted-imports`), `create<Props, Result>` resolve typing, and removal of the stale `useModal<TResult>()` / `show<TProps, TResult>()` / `shadcnModalAdapter` references.

Closes #69, #70, #71, #72, #73.

## Breaking change

`ShadCNModalProps.afterClose` → `onOpenChangeComplete`. Shipped as a 0.x **minor** (0.2.0 → 0.3.0) per semver's 0.x convention. Consumers spreading `{...modal.modalProps}` onto a dialog are unaffected (and stop leaking); anyone reading `modalProps.afterClose` by hand switches to `onOpenChangeComplete`.

## Verification

- Package: 160 runtime tests, 8 `expectTypeOf` type tests, coverage 99.05 / 100 / 96 / 99.05 (≥ 90/90/85/90), full `tsc` clean, tsdown build OK.
- Registry / root: 225 tests, root `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)