### PR TITLE
docs(adr): ADR-0004 props vocabulary — slogans → executable criteria

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,9 +84,18 @@ modal.hide()
 - **底层原语** (`components/ui/*`)：shadcn 原生 compound component（如 `<Card><CardHeader><CardTitle>...`），保留完整组合自由度
 - **Compose 层** (`registry/ui/*`)：基于原语的扁平化封装，用 props 代替 children 结构
 
-### 核心原则：80/20
+### 核心原则：规则 A（覆盖面浮动）+ 规则 B（基础用例概念数冻结）
 
-Compose 层服务 **80% 常见场景**，牺牲灵活性换取易用性。复杂的 20% 场景，用户直接使用 `components/ui/*` 原语自己组合，**不在 Compose 层开口子**。这是一条硬线——每次想加 prop 时都要回到这条线上问一遍。
+不再用统一的 80/20 固定百分比做硬线。判据全文见 [ADR-0004](docs/adr/0004-props-vocabulary.md)，落到执行是两条规则：
+
+**规则 A：覆盖目标随"逃生成本"浮动。** Compose 组件分两级——
+
+- **薄封装**（Card、Tabs、Tooltip、Breadcrumb、Accordion、Popover 这类）：用户回退原语手写只要十几行，逃生舱近乎免费 → API 保持极小，缺失场景直接让用户走原语。
+- **状态机组件**（Table、Select、Combobox、DatePicker 这类）：Compose 层拥有真正的状态逻辑（选中 tally、异步竞态、已选项 merge-back），"去用原语"等于重写几百行 → 覆盖率有义务逼近 100%，对标 antd 同类组件的能力面。`table.tsx` 的 `getCheckboxProps` 不是"例外"，正是这条规律：Table 是状态机组件，暴露逐行 checkbox 控制属于分内覆盖。
+
+**规则 B：基础用例概念数冻结。** props 总数可以涨，但"跑通第一个用例必须理解的 props 数"永久冻结——Table 永远是 `columns` + `dataSource` + `rowKey`，Select 永远是 `items` + `value`/`onValueChange`。新 prop 必须做到"不用它的人完全无感知"：有合理默认；不与既有 props 产生互斥/组合语义（若确有互斥关系，**必须**写进该 prop 的 JSDoc）；不出现在第一个 demo 里。
+
+一句话：**面积可以逼近 100%，入门斜率必须保持 80% 时的样子。**
 
 ### 新增组件时的规则
 
@@ -100,15 +109,23 @@ Compose 层服务 **80% 常见场景**，牺牲灵活性换取易用性。复杂
 <Card><CardHeader><CardTitle>...</CardTitle></CardHeader>...</Card>
 ```
 
-**2. 每个 slot 默认只暴露 `xxxClassName`，克制地使用 `xxxProps`**
+**2. `xxxProps` 按 slot 内容分三类，核心是"所有权类型收口"**
 
-- 命名模式：`titleClassName`、`descriptionClassName`、`footerClassName`、`contentClassName`
-- `xxxProps` 允许但必须克制：仅当 slot 确有高频的非样式定制需求（典型如按钮 slot 的 `variant` / `disabled` / `loading`）才暴露，且类型必须收窄为该 slot 真实组件的 props（禁止 `Record<string, unknown>` 兜底）
-- 默认不加：能用 `xxxClassName` 表达的、或只为 5% 场景服务的 `xxxProps` 一律不加——去用原语
+要不要给 slot 开 `xxxProps`，取决于 slot 内容是什么、状态归谁所有，而不是"克制"的直觉。判据全文见 [ADR-0004](docs/adr/0004-props-vocabulary.md)：
 
-**3. 命名对齐原语**
+- **内容型 slot**（`title` / `description` / `footer` / `content` 等，类型是 `ReactNode`）：**永远不加 `xxxProps`**。slot 内部本就 100% 可控，唯一够不到的是包裹元素，而包裹元素只有样式需求 → `xxxClassName` 封顶。硬规则。
+- **交互组件型 slot**（按钮、checkbox、input 等有自己 props 面的组件）：`xxxProps` 合理，数量不设限，但**必须在类型层面 `Omit` 掉 Compose 层已接管的键**（`onClick`、`checked`、`onCheckedChange`、`children`…），不能只靠文档约定——passthrough 的展开会在运行时静默盖掉内部逻辑。类型仍须收窄为该 slot 真实组件的 props（禁止 `Record<string, unknown>` 兜底）。正例：`registry/ui/table.tsx` 的 `TableCheckboxProps` 用 `Omit` 收口了状态键。
+- **Compose 状态需流入 slot 的**：用函数形式 `(record, index) => Partial<Props>`（`getCheckboxProps` 模式），同样 `Omit` 状态键，且函数必须**纯、不抛异常**（每行每次渲染都会调用，抛错会卸载整棵树）。
 
-减少用户记忆成本。例如 shadcn 叫 `TabsList`，所以用 `listClassName`（✗ `tabBarClassName`）。
+判词：**数量从来不是问题，未收口的所有权才是问题。**
+
+**3. 命名按参照系优先级裁决**
+
+命名参照系有固定优先级（判据全文见 [ADR-0004](docs/adr/0004-props-vocabulary.md)）：
+
+1. **原语已有的概念 → 对齐原语**（最高优先级，逃生时心智不换轨）。例如 shadcn 叫 `TabsList`，所以用 `listClassName`（✗ `tabBarClassName`）。因此 `Select` 用 `multiple: boolean`（对齐 base-ui）而 `DatePicker` 用 `mode: "single" | "multiple" | "range"`（对齐 react-day-picker）——这种横向不一致是**可接受的代价**，不强扭。
+2. **Compose 层自造的概念 → 必须对齐兄弟组件**，写进标准词汇表：受控三件套 `value` / `defaultValue` / `onValueChange`、`open` / `defaultOpen` / `onOpenChange`；异步组 `loading` / `loadingMessage` / `loadItems` / `loadOn` / `debounceMs`；空态组 `emptyMessage` / `emptyClassName`；列表约定 `items: Item[]`（每项 `value` + 内容字段 + `disabled` + 各 `xxxClassName`）；slot 名 `title` / `description` / `action` / `footer` / `content` / `trigger`，配套 `xxxClassName`。
+3. **冲突裁决 → 跟随原语子组件名**。当 1、2 打架时，原语渲染出的子组件名胜出：`TabsTrigger` 渲染 tab，故 tabs item 的内容字段应叫 `trigger`；`RadioGroupItem` 渲染 `<label>`，故 `radio-group` / `checkbox-group` 保持 `label`——正确。
 
 **4. 默认行为可以反转原语默认**
 
@@ -121,7 +138,7 @@ Compose 层服务 **80% 常见场景**，牺牲灵活性换取易用性。复杂
 - ❌ `renderHeader` / `renderFooter` 这类 render prop
 - ❌ `slots` 对象（MUI 风格）
 - ❌ "在 A 和 B 中间插入自定义节点"的 prop
-- ❌ 为了 5% 场景新增的任何 prop
+- ❌ 违反规则 A/B 的 prop：薄封装里为边缘场景开的口子，或任何抬高"基础用例概念数"的 prop
 
 遇到此类需求，答案永远是："**去用 `components/ui/*` 原语**"。
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -4,6 +4,7 @@
 
 - **Compose layer**: The `registry/ui/*` components that wrap shadcn primitives with flat props.
 - **Primitive**: The raw `components/ui/*` shadcn components with full composition freedom.
+- **Thin wrapper vs. State-machine component**: The two Compose tiers. A **thin wrapper** (Card, Tabs, Tooltip, Breadcrumb, Accordion, Popover) adds almost no logic — escaping to the primitive costs ~a dozen lines, so its API stays minimal. A **state-machine component** (Table, Select, Combobox, DatePicker) owns real state logic (selection tally, async race, selected-item merge-back), so escaping is expensive and its coverage is obligated to approach 100%. This tier decides how much a Compose component must cover. See [ADR-0004](docs/adr/0004-props-vocabulary.md).
 - **Command-modal**: The imperative modal state-management library in `packages/command-modal/`.
 - **Handler**: The object `useModal()` returns — the modal's live state (`visible`, `args`, …) plus the imperative verbs (`show`, `hide`, `remove`, `resolve`, `reject`, `resolveHide`). The unit an Adapter consumes.
 - **Adapter** (`ModalPropsAdapter`): A pure function mapping a Handler to the prop shape one modal UI library expects (e.g. shadcn `{ open, onOpenChange }`, antd `{ open, onCancel, afterClose }`). The single seam by which command-modal stays UI-library-agnostic.
@@ -15,7 +16,7 @@
 ## Key decisions
 
 - Dual-layer architecture: primitives (`components/ui/*`) + Compose layer (`registry/ui/*`)
-- 80/20 rule: Compose layer serves 80% of common use cases
+- Compose API sizing & vocabulary: no single 80/20 hard line — coverage floats with escape cost (thin-wrapper vs state-machine tiers; area may approach 100%), the base-case concept count stays frozen, `xxxProps` is ownership-type-narrowed (`Omit` the keys Compose owns), and props naming follows a fixed reference order. See [ADR-0004](docs/adr/0004-props-vocabulary.md).
 - `components/ui/**` is read-only, only modified via shadcn CLI
 - command-modal's only UI-library coupling is the Adapter seam; the core stays UI-agnostic. First-class targets are shadcn + antd v6; other libraries are typed-but-BYO. See [ADR-0001](docs/adr/0001-adapter-seam-and-typed-factory.md).
 - A modal's resolve (result) type is carried on `create<Props, Result>`, not at the `show()` call site. See [ADR-0002](docs/adr/0002-resolve-type-on-create.md).

--- a/docs/adr/0004-props-vocabulary.md
+++ b/docs/adr/0004-props-vocabulary.md
@@ -1,0 +1,58 @@
+# Props vocabulary: coverage tiers, ownership-typed `xxxProps`, and a naming reference order
+
+Three slogans in the Compose-layer design guidance were carrying more weight than they could bear: a single **80/20 hard line** for every component, a blanket **"only expose `xxxClassName`, use `xxxProps` sparingly"**, and **"align names to the primitive"** with no tie-breaker. Each collapses distinct cases into one rule and forces a coin-flip whenever the case doesn't fit. This ADR replaces the three slogans with executable criteria. It changes no runtime behaviour; it records how to decide the shape of a Compose component's props surface, and names two known deviations to clean up.
+
+## Decision
+
+### 1. Two rules replace the flat 80/20 line
+
+The unified "Compose serves 80%, the other 20% drops to the primitive" hard line is abolished. It conflated two independent questions — *how much should this component cover?* and *how big is the base case?* — and answered both with the same fixed percentage. Split them:
+
+**Rule A — the coverage target floats with the escape cost.** Compose components fall into two tiers:
+
+- **Thin wrappers** (Card, Tabs, Tooltip, Breadcrumb, Accordion, Popover): rebuilding the missing case by hand on the primitive costs a dozen-odd lines. The escape hatch is nearly free, so the API stays **minimal** — a missing scenario routes straight to the primitive.
+- **State-machine components** (Table, Select, Combobox, DatePicker): the Compose layer owns real state logic — selection tally, async race resolution, selected-item merge-back — that the primitive does not. "Use the primitive" here means rewriting hundreds of lines, so the escape hatch is expensive. These components have an **obligation to approach 100% coverage**, benchmarked against the capability surface of the equivalent antd component.
+
+`table.tsx`'s `getCheckboxProps`, approved at the time as an explicit "exception" to the no-`xxxProps` guidance, is not an exception — it is exactly this rule: Table is a state-machine component, so surfacing per-row checkbox control is in-scope coverage, not an escape from the line.
+
+**Rule B — the base-case concept count is frozen.** The *total* prop count may grow without limit; the number of props you must understand to run the **first** use case is frozen forever. Table is always `columns` + `dataSource` + `rowKey`. Select is always `items` + `value`/`onValueChange`. A new prop is admissible only if someone who doesn't use it stays completely unaware of it:
+
+- it has a sensible default;
+- it introduces no mutual-exclusion or combination semantics with existing props — and if a mutual-exclusion relationship genuinely exists, it **must** be spelled out in the prop's JSDoc, not left implicit;
+- it does not appear in the component's first demo.
+
+One line: **the area may approach 100%, but the onboarding slope must stay what it was at 80%.**
+
+### 2. `xxxProps` by slot ownership — three categories
+
+Whether a slot gets an `xxxProps` escape is decided by *what the slot's content is and who owns its state*, not by a "use sparingly" instinct. Three categories:
+
+1. **Content slots** — `title`, `description`, `footer`, `content`, etc., whose type is `ReactNode`. **Never add `xxxProps`.** The slot interior is already 100% caller-controlled (they hand you the node); the only thing they can't reach is the wrapping element, and a wrapper has nothing but styling needs. `xxxClassName` is the ceiling. This is a hard rule.
+2. **Interactive-component slots** — buttons, checkboxes, inputs: components with their own props surface. `xxxProps` is legitimate and its count is **not** capped. But it **must Omit, at the type level, every key the Compose layer has taken over** (`onClick`, `checked`, `onCheckedChange`, `children`, …) — a documentation note is not enough, because a passthrough spread will silently win at runtime.
+   - Positive example: `registry/ui/table.tsx`'s `TableCheckboxProps` is `Omit<…, "checked" | "children" | "defaultChecked" | "indeterminate" | "onCheckedChange">`, so no external prop can desync the selection state.
+   - Counter-example (known debt, see Consequences): `registry/ui/alert-dialog.tsx`'s `confirmProps` / `cancelProps` are the un-narrowed full `ComponentProps<typeof AsyncButton>`, spread *after* the dialog's own `onClick`. A caller-passed `onClick` silently overrides the internal `onConfirm`/`onCancel` + `close()` wiring.
+3. **Slots the Compose state must flow into** — use the function form `(record, index) => Partial<Props>` (the `getCheckboxProps` pattern). It, too, Omits the state keys, and the function is required to be **pure and non-throwing** (it runs for every row on every render; throwing unmounts the surrounding tree).
+
+Verdict: **count was never the problem; un-narrowed ownership is.**
+
+### 3. Props naming — a reference-frame priority order
+
+Names are chosen against a fixed priority of reference frames:
+
+1. **The primitive already has the concept → align to the primitive.** Highest priority: when a user escapes to the primitive their mental model must not have to switch tracks. This is why `Select` uses `multiple: boolean` (aligned to base-ui) while `DatePicker` uses `mode: "single" | "multiple" | "range"` (aligned to react-day-picker). The resulting **horizontal** inconsistency between the two Compose components is an **acceptable cost** — do not force-align it.
+2. **A Compose-invented concept → must align to sibling Compose components.** These are written into a standard vocabulary:
+   - **Controlled triple**: `value` / `defaultValue` / `onValueChange`; `open` / `defaultOpen` / `onOpenChange`.
+   - **Async group**: `loading` / `loadingMessage` / `loadItems` / `loadOn` / `debounceMs`.
+   - **Empty group**: `emptyMessage` / `emptyClassName`.
+   - **List convention**: `items: Item[]`, each item carrying `value` + a content field + `disabled` + its per-item `xxxClassName`s.
+   - **Slot names**: `title` / `description` / `action` / `footer` / `content` / `trigger`, each paired with its `xxxClassName`.
+   - **Boolean dual form**: `boolean | { … }` (e.g. `dividers`) — a bare boolean for the simple case, an object when it needs configuring.
+3. **Conflict adjudication → follow the primitive's *child component* name.** When frames 1 and 2 disagree, the primitive's child element name wins. `TabsTrigger` renders the tab, so a tabs item's content field should be `trigger`. `RadioGroupItem` renders a `<label>`, so `radio-group` / `checkbox-group` keep `label` — correct as-is.
+
+## Consequences
+
+- **Sanctioned inconsistency.** `multiple` (Select) vs `mode` (DatePicker) is now explicitly an acceptable cost of frame-1 primitive alignment, not a defect. Reviewers should not "harmonize" it.
+- **Cleanup item — `alert-dialog.tsx` ownership narrowing.** `confirmProps` / `cancelProps` must be narrowed to `Omit` the keys the dialog owns (at minimum `onClick`, plus the confirm/cancel wiring). Until then it is the standing counter-example for category 2 above. To be fixed in a later PR.
+- **Cleanup item — `tabs.tsx` `label` → `trigger`.** The tabs item content field is currently `label`, a legacy deviation from frame-3 adjudication (`TabsTrigger`) that also contradicts the component's own `triggerClassName`. Rename to `trigger` in a later PR.
+- **Stale comment in `table.tsx`.** `getCheckboxProps`'s JSDoc still calls itself "an explicit exception to AGENTS.md's 'no xxxProps' rule". Under Rule A it is the rule, and AGENTS.md no longer states a blanket no-`xxxProps` rule; the comment is stale and should be reworded the next time `table.tsx` is touched (`components/ui/**`/`registry/**` are out of scope for this doc-only change).
+- Future component reviews decide props by Rules A/B (sizing), the three slot categories (`xxxProps`), and the reference-frame order (naming) — no more coin-flips at the 80/20 line.


### PR DESCRIPTION
## What

落 ADR-0004（props 词汇表），把 Compose 层三处"口号式"设计原则换成"可执行判据"。**纯文档，不改任何代码。**

## Changes

- **`docs/adr/0004-props-vocabulary.md`（新建）** — 收录三条定稿结论：
  1. **废除统一 80/20 硬线 → 规则 A + B**。规则 A：覆盖目标随"逃生成本"浮动（薄封装 vs 状态机组件，后者覆盖率逼近 100%，对标 antd）。规则 B：基础用例概念数冻结（Table 永远 `columns`+`dataSource`+`rowKey`，Select 永远 `items`+`value`/`onValueChange`）。
  2. **`xxxProps` 按 slot 内容分三类**，核心是"所有权类型收口"——内容型永不加、交互组件型必须 `Omit` 掉 Compose 已接管的键、状态流入型用 `(record,index)=>Partial<Props>` 函数形式。
  3. **命名参照系优先级** + 冲突裁决（跟随原语子组件名）。
  - Consequences 列出两处已知存量偏差作为待清理项：`alert-dialog` 的 `confirm/cancelProps` 未收口、`tabs` item 字段 `label`→`trigger`。
- **`AGENTS.md`** — 手术式改写 "Component Design Philosophy"：核心原则 80/20 → 规则 A/B；规则 2（xxxProps）→ 三类判据 + 类型收口；规则 3（命名）→ 参照系优先级 + 冲突裁决。规则 1/4/5/6/7 保持原样（仅规则 5 一条与规则 A 直接矛盾的 bullet 微调）。
- **`CONTEXT.md`** — Domain language 增"薄封装 vs 状态机组件"分级词条；Key decisions 的旧 80/20 行改写为指向 ADR-0004。

## Notes

- `table.tsx` 的 `getCheckboxProps` 从"例外"重定位为规律本身（ADR + AGENTS 均已体现）。
- 未触碰 `packages/**` / `.changeset/**` / `components/ui/**` / `registry/**` / `README*`。
- 自查：无残留互相矛盾的 80/20 表述（rules 4/6 里的"80%"是口语化的"多数用户"，非硬线，保留）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)