### PR TITLE
docs(readme): cover full catalogue and align philosophy to ADR-0004

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 <p align="center"><em>the easy way to shadcn.</em></p>
 
 <p align="center">
-  Hand-stitched wrappers over <a href="https://ui.shadcn.com">shadcn/ui</a> that swap nested children for <strong>flat props</strong>.
+  Flat-prop wrappers over <a href="https://ui.shadcn.com">shadcn/ui</a>: nested children collapse into one tag, and the data-driven components — Table, Select, Combobox, Date Picker — ship <strong>antd-grade DX</strong> on the shadcn base.
   <br/>
-  Eighty percent of your UI ships with one tag. The other twenty — drop down to the primitive.
+  Installed through the shadcn CLI, so the code lands in your repo and the primitive is always one import away.
 </p>
 
 <p align="center">
@@ -36,36 +36,76 @@ pnpm dlx shadcn@latest add @easy-shadcn/card
 
 See the [installation guide](https://easy-shadcn.vercel.app/docs/installation) for the full setup, including the namespace alias and the alternative URL form.
 
+Every wrapper trades a nested ladder for flat props. Card, before and after:
+
+```tsx
+// shadcn primitive — nested children
+<Card>
+  <CardHeader>
+    <CardTitle>Team plan</CardTitle>
+    <CardDescription>Billed monthly</CardDescription>
+    <CardAction><Button size="sm">Upgrade</Button></CardAction>
+  </CardHeader>
+  <CardContent>Everything in Pro, plus SSO.</CardContent>
+  <CardFooter>$30 / user / month</CardFooter>
+</Card>
+
+// easy-shadcn — one tag, flat props
+<Card
+  title="Team plan"
+  description="Billed monthly"
+  action={<Button size="sm">Upgrade</Button>}
+  footer="$30 / user / month"
+>
+  Everything in Pro, plus SSO.
+</Card>
+```
+
 ## Components
+
+The four data-driven components lead the list: **Table**, **Select**, **Combobox** and **Date Picker** own real state — selection tallies, async races, single / multiple / range logic — and aim for the capability surface of their antd equivalent, still shipped as copy-in registry source.
 
 | Component | What it collapses | Install |
 |-----------|-------------------|---------|
+| **Table** | `columns` + `dataSource` + `rowKey` replace hand-built `<thead>` / `<tbody>` markup, with built-in loading / empty / caption states and row selection (controlled or uncontrolled, indeterminate select-all, per-row gating) | `@easy-shadcn/table` |
+| **Select** | Dropdown, searchable, multi-select chips and async / server-side-filtered loading in one `items` / `loadItems`-driven component | `@easy-shadcn/select` |
+| **Combobox** | An always-searchable, single-select autocomplete preset over Select | `@easy-shadcn/combobox` |
+| **Date Picker** | Single / multiple / range under one `mode` prop, with an optional typed-input trigger and min / max / disabled-date bounds | `@easy-shadcn/date-picker` |
 | **Card** | `<CardHeader><CardTitle>…` ladders into flat `title` / `description` / `action` / `footer` props | `@easy-shadcn/card` |
-| **Tabs** | A whole `<TabsList>` + repeated triggers into an `items={…}` array | `@easy-shadcn/tabs` |
-| **Async Button** | Manual `useState` loading dance for any `onClick` returning a Promise | `@easy-shadcn/async-button` |
-| **Modal** | Imperative `alert` / `confirm` helpers + a composable Modal on top of shadcn Dialog | `@easy-shadcn/modal` |
-| **Calendar** | Native month/year dropdowns into a three-view button-grid navigation | `@easy-shadcn/calendar` |
-| **Date Picker** | Single / multiple / range / inline-input variants under one component | `@easy-shadcn/date-picker` |
-| **Accordion** | The repeated `<AccordionItem><AccordionTrigger>…<AccordionContent>…` triple into an `items={…}` array of `{ value, trigger, content }` | `@easy-shadcn/accordion` |
-| **Breadcrumb** | Hand-nested `<BreadcrumbList>` / `<BreadcrumbItem>` / `<BreadcrumbLink>` / `<BreadcrumbSeparator>` markup into an `items={…}` array | `@easy-shadcn/breadcrumb` |
+| **Tabs** | A whole `<TabsList>` + repeated triggers into an `items={…}` array of `{ value, trigger, content }` | `@easy-shadcn/tabs` |
+| **Accordion** | The repeated `<AccordionItem><AccordionTrigger>…<AccordionContent>…` triple into an `items={…}` array of `{ value, trigger, content }`, single or multiple open | `@easy-shadcn/accordion` |
+| **Breadcrumb** | Hand-nested `<BreadcrumbList>` / `<BreadcrumbItem>` / `<BreadcrumbLink>` / `<BreadcrumbSeparator>` markup into an `items={…}` array, with auto current-page and `maxItems` ellipsis | `@easy-shadcn/breadcrumb` |
 | **Tooltip** | The `<TooltipProvider>` / `<Tooltip>` / `<TooltipTrigger>` / `<TooltipContent>` nest into one `children` trigger plus a `content` prop | `@easy-shadcn/tooltip` |
+| **Popover** | The base-ui Popover parts into one `children` trigger plus `title` / `description` / `content` / `footer` slots | `@easy-shadcn/popover` |
 | **Radio Group** | Hand-wired `<RadioGroupItem>` controls plus their `<label>` / description markup into an `items={…}` array of `{ value, label, description }` | `@easy-shadcn/radio-group` |
+| **Checkbox Group** | The multi-select counterpart — checkbox + `<label>` / description markup into an `items={…}` array of `{ value, label, description }` | `@easy-shadcn/checkbox-group` |
+| **Field** | Label, control, description, a required marker and validation messages into one form-field wrapper (accepts React Hook Form / Zod error arrays) | `@easy-shadcn/field` |
+| **Async Button** | The manual `useState` loading dance for any `onClick` returning a Promise | `@easy-shadcn/async-button` |
+| **Alert Dialog** | A confirm / cancel dialog with `title` / `description` slots, async handlers, a destructive variant and controlled or uncontrolled open state | `@easy-shadcn/alert-dialog` |
+| **Modal** | Imperative `alert` / `confirm` helpers plus a composable Modal on top of shadcn Dialog | `@easy-shadcn/modal` |
+| **Calendar** | Native month / year dropdowns into a three-view (days / months / years) button-grid navigation | `@easy-shadcn/calendar` |
+
+### Hooks
+
+| Hook | What it does | Install |
+|------|--------------|---------|
+| **useDelayLoading** | Adds a minimum visible duration to a loading state, so spinners don't flash on fast operations | `@easy-shadcn/use-delay-loading` |
+| **useSelectItems** | Turns a flat `SelectItem[]` into the lookups and default `contains` filter a Select-like UI needs | `@easy-shadcn/use-select-items` |
+| **useSelectLoader** | Async options loader with eager or server-side-filter modes, `AbortController`, debounce and a selected-item cache | `@easy-shadcn/use-select-loader` |
 
 ## Design Philosophy
 
-easy-shadcn is a **compose layer** for shadcn/ui — never a replacement. The 80/20 rule is the only rule:
+easy-shadcn is a **compose layer** over shadcn/ui — installed through the CLI, so every component lands in your repo as ordinary source you own and can patch. Three rules keep it honest:
 
-- **Flat props, not nested children.** One prop per slot. `<Card title="…" footer={…}>body</Card>` instead of a four-deep `<CardHeader><CardTitle>…` ladder.
-- **Compose layer earns its way in.** A component only joins when it collapses a recurring shadcn pattern into something you'd type without thinking. Three copy-pastes is the threshold.
-- **No render props. No slot objects.** Need the other 20%? Drop down to `components/ui/*` — the primitive door is unlocked. The compose layer never grows another API door.
-- **Names align with primitives.** If shadcn calls it `TabsList`, the prop is `listClassName` — not a new vocabulary to learn.
-- **Your code, your repo.** Installed through the shadcn CLI. Every component lives inside your project, fully owned and trivially patched. No black box.
+- **Thin wrappers stay thin; state-machine components go deep.** A wrapper like Card or Tabs exists only to fold a recurring nested pattern into flat props — rebuilding the missing case on the primitive costs a dozen lines, so the API stays minimal. Table, Select, Combobox and Date Picker own real state (selection tallies, async races, selected-item merge-back); rewriting that by hand costs hundreds of lines, so they carry an obligation to approach the capability surface of their antd equivalent.
+- **The onboarding slope is frozen.** Total prop counts may grow without limit, but the number of props you must understand to run the *first* use case never moves. Table is always `columns` + `dataSource` + `rowKey`; Select is always `items` + `value` / `onValueChange`. A new prop is admissible only if someone who never uses it stays unaware it exists.
+- **The primitive door is unlocked.** No render props, no slot objects, no "insert a node between A and B" escape hatches. Need the last stretch of flexibility? Drop down to `components/ui/*` — the compose layer never grows a second API door to get you there.
 
-Read the [full design notes](./AGENTS.md#component-design-philosophy) for the reasoning behind each rule.
+Read the [full design notes](./AGENTS.md#component-design-philosophy) and [ADR-0004](./docs/adr/0004-props-vocabulary.md) for the reasoning behind each rule.
 
 ## Status
 
-🚧 easy-shadcn is in active early development. The compose-layer rules above are stable; the component catalogue is growing slowly on purpose.
+🚧 easy-shadcn is in active early development. The compose-layer rules above are stable; the component catalogue grows deliberately.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,9 +10,9 @@
 <p align="center"><em>更简单的 shadcn 使用方式。</em></p>
 
 <p align="center">
-  在 <a href="https://ui.shadcn.com">shadcn/ui</a> 之上手工封装的轻量层，把嵌套 children 换成<strong>扁平 props</strong>。
+  在 <a href="https://ui.shadcn.com">shadcn/ui</a> 之上的扁平 props 封装：嵌套 children 折叠成一个标签，而数据驱动的组件——Table、Select、Combobox、Date Picker——在 shadcn 底座上提供 <strong>antd 级别的开箱 DX</strong>。
   <br/>
-  80% 的 UI 一行搞定，剩下 20% 直接下沉到原语层。
+  通过 shadcn CLI 安装，代码落进你自己的仓库，原语始终只差一个 import。
 </p>
 
 <p align="center">
@@ -36,36 +36,76 @@ pnpm dlx shadcn@latest add @easy-shadcn/card
 
 完整步骤（包括 namespace 别名和直链方式）见 [安装指南](https://easy-shadcn.vercel.app/docs/installation)。
 
+每个封装都把嵌套梯子换成扁平 props。以 Card 为例，前后对比：
+
+```tsx
+// shadcn 原语 —— 嵌套 children
+<Card>
+  <CardHeader>
+    <CardTitle>Team plan</CardTitle>
+    <CardDescription>Billed monthly</CardDescription>
+    <CardAction><Button size="sm">Upgrade</Button></CardAction>
+  </CardHeader>
+  <CardContent>Everything in Pro, plus SSO.</CardContent>
+  <CardFooter>$30 / user / month</CardFooter>
+</Card>
+
+// easy-shadcn —— 一个标签，扁平 props
+<Card
+  title="Team plan"
+  description="Billed monthly"
+  action={<Button size="sm">Upgrade</Button>}
+  footer="$30 / user / month"
+>
+  Everything in Pro, plus SSO.
+</Card>
+```
+
 ## 组件清单
+
+四个数据驱动组件排在最前：**Table**、**Select**、**Combobox**、**Date Picker** 拥有真正的状态——选中 tally、异步竞态、单选 / 多选 / 范围逻辑——对标 antd 同类组件的能力面，同时仍以 copy-in 的 registry 源码分发。
 
 | 组件 | 折叠了什么 | 安装 |
 |------|-----------|------|
+| **Table** | `columns` + `dataSource` + `rowKey` 取代手写的 `<thead>` / `<tbody>` 结构，内置 loading / 空态 / caption 状态和行选择（受控或非受控、半选全选、逐行控制） | `@easy-shadcn/table` |
+| **Select** | 下拉、可搜索、多选 chips、异步 / 服务端过滤加载，统一在一个由 `items` / `loadItems` 驱动的组件里 | `@easy-shadcn/select` |
+| **Combobox** | 始终可搜索的单选自动补全，Select 之上的预设 | `@easy-shadcn/combobox` |
+| **Date Picker** | 单选 / 多选 / 范围统一在一个 `mode` prop 下，可选的输入框触发器，以及 min / max / 禁用日期边界 | `@easy-shadcn/date-picker` |
 | **Card** | `<CardHeader><CardTitle>…` 嵌套梯子 → 扁平 `title` / `description` / `action` / `footer` props | `@easy-shadcn/card` |
-| **Tabs** | 完整的 `<TabsList>` + 一堆 trigger → 一个 `items={…}` 数组 | `@easy-shadcn/tabs` |
-| **Async Button** | `onClick` 返回 Promise 的手动 `useState` loading 流程 | `@easy-shadcn/async-button` |
-| **Modal** | 命令式 `alert` / `confirm` 助手 + 基于 shadcn Dialog 的组合式 Modal | `@easy-shadcn/modal` |
-| **Calendar** | 原生月/年下拉 → 三视图按钮网格切换 | `@easy-shadcn/calendar` |
-| **Date Picker** | 单选 / 多选 / 范围 / inline-input 多形态合一 | `@easy-shadcn/date-picker` |
-| **Accordion** | 每行重复的 `<AccordionItem><AccordionTrigger>…<AccordionContent>…` 三件套 → 一个 `items={…}` 数组（`{ value, trigger, content }`） | `@easy-shadcn/accordion` |
-| **Breadcrumb** | 手写嵌套的 `<BreadcrumbList>` / `<BreadcrumbItem>` / `<BreadcrumbLink>` / `<BreadcrumbSeparator>` → 一个 `items={…}` 数组 | `@easy-shadcn/breadcrumb` |
+| **Tabs** | 完整的 `<TabsList>` + 一堆 trigger → 一个 `items={…}` 数组（`{ value, trigger, content }`） | `@easy-shadcn/tabs` |
+| **Accordion** | 每行重复的 `<AccordionItem><AccordionTrigger>…<AccordionContent>…` 三件套 → 一个 `items={…}` 数组（`{ value, trigger, content }`），单开或多开 | `@easy-shadcn/accordion` |
+| **Breadcrumb** | 手写嵌套的 `<BreadcrumbList>` / `<BreadcrumbItem>` / `<BreadcrumbLink>` / `<BreadcrumbSeparator>` → 一个 `items={…}` 数组，自动识别当前页，`maxItems` 折叠省略号 | `@easy-shadcn/breadcrumb` |
 | **Tooltip** | `<TooltipProvider>` / `<Tooltip>` / `<TooltipTrigger>` / `<TooltipContent>` 四层嵌套 → 一个 `children` 触发元素 + 一个 `content` prop | `@easy-shadcn/tooltip` |
+| **Popover** | base-ui Popover 各部件 → 一个 `children` 触发元素 + `title` / `description` / `content` / `footer` slot | `@easy-shadcn/popover` |
 | **Radio Group** | 逐个手接的 `<RadioGroupItem>` 控件 + `<label>` / 描述结构 → 一个 `items={…}` 数组（`{ value, label, description }`） | `@easy-shadcn/radio-group` |
+| **Checkbox Group** | 多选版对应物——checkbox + `<label>` / 描述结构 → 一个 `items={…}` 数组（`{ value, label, description }`） | `@easy-shadcn/checkbox-group` |
+| **Field** | label、控件、描述、必填标记和校验信息 → 一个表单字段封装（接受 React Hook Form / Zod 的 error 数组） | `@easy-shadcn/field` |
+| **Async Button** | `onClick` 返回 Promise 的手动 `useState` loading 流程 | `@easy-shadcn/async-button` |
+| **Alert Dialog** | confirm / cancel 确认对话框，带 `title` / `description` slot、异步处理函数、destructive 变体，以及受控或非受控的开合状态 | `@easy-shadcn/alert-dialog` |
+| **Modal** | 命令式 `alert` / `confirm` 助手 + 基于 shadcn Dialog 的组合式 Modal | `@easy-shadcn/modal` |
+| **Calendar** | 原生月 / 年下拉 → 三视图（日 / 月 / 年）按钮网格切换 | `@easy-shadcn/calendar` |
+
+### Hooks
+
+| Hook | 做什么 | 安装 |
+|------|--------|------|
+| **useDelayLoading** | 给 loading 状态加一个最小可见时长，避免快操作时 spinner 一闪而过 | `@easy-shadcn/use-delay-loading` |
+| **useSelectItems** | 把扁平的 `SelectItem[]` 转成 Select 类 UI 需要的查找函数和默认 `contains` 过滤 | `@easy-shadcn/use-select-items` |
+| **useSelectLoader** | 异步选项加载器，支持一次性加载或服务端过滤两种模式，带 `AbortController`、防抖和已选项缓存 | `@easy-shadcn/use-select-loader` |
 
 ## 设计理念
 
-easy-shadcn 是 shadcn/ui 的**组合层**，绝不是替代品。整个项目只有一条规则——80/20：
+easy-shadcn 是 shadcn/ui 的**组合层**——通过 CLI 安装，每个组件都以你自己拥有、可以随手改的普通源码落进你的仓库。三条规则让它保持诚实：
 
-- **扁平 props，不要嵌套 children。** 一个 prop 对应一个 slot。用 `<Card title="…" footer={…}>body</Card>` 替代四层深的 `<CardHeader><CardTitle>…` 梯子。
-- **每个组件都得自己挣进来。** 只有当它能把重复的 shadcn 写法折叠成一行你不假思索就敲得出的代码时，才被加入。复制粘贴三次以上是门槛。
-- **拒绝 render props 和 slot 对象。** 需要剩下的 20%？直接下沉到 `components/ui/*` — 原语层的大门始终敞开。组合层永远不会再开第二道 API 口。
-- **命名对齐原语。** shadcn 叫 `TabsList`，prop 就叫 `listClassName`——不发明新词汇，不增加记忆成本。
-- **代码归你所有。** 通过 shadcn CLI 安装到你的项目，每个组件都活在你的仓库里，可以随手改、随时修。没有黑盒。
+- **薄封装保持极小；状态机组件做深。** 像 Card、Tabs 这样的封装只为把重复的嵌套写法折叠成扁平 props——回退原语手写缺失场景只要十几行，所以 API 保持极小。Table、Select、Combobox、Date Picker 拥有真正的状态（选中 tally、异步竞态、已选项 merge-back），手写重来要几百行，所以它们有义务逼近 antd 同类组件的能力面。
+- **入门斜率永久冻结。** props 总数可以无上限地涨，但"跑通第一个用例必须理解的 props 数"永远不动。Table 永远是 `columns` + `dataSource` + `rowKey`，Select 永远是 `items` + `value` / `onValueChange`。新 prop 只有在"不用它的人完全无感知它存在"时才允许加入。
+- **原语的大门始终敞开。** 没有 render props，没有 slot 对象，没有"在 A 和 B 之间插入节点"的逃生口。需要最后那一段灵活性？直接下沉到 `components/ui/*`——组合层永远不会为此再开第二道 API 口。
 
-每条规则背后的推理见 [完整设计笔记](./AGENTS.md#component-design-philosophy)。
+每条规则背后的推理见 [完整设计笔记](./AGENTS.md#component-design-philosophy) 和 [ADR-0004](./docs/adr/0004-props-vocabulary.md)。
 
 ## 状态
 
-🚧 easy-shadcn 仍在早期开发中。上面的组合层规则已经稳定，组件清单刻意地慢慢生长。
+🚧 easy-shadcn 仍在早期开发中。上面的组合层规则已经稳定，组件清单在刻意地稳步生长。
 
 ## License
 


### PR DESCRIPTION
## What

Rewrite `README.md` and `README.zh-CN.md` so they honestly reflect the current library. Only these two files change.

## Why

The old README listed 10 components while the registry ships 17 components + 3 hooks — the absent ones (Table, Select, Combobox, Checkbox Group, Field, Popover, Alert Dialog) are the most persuasive. The Design Philosophy section still used the retired "80/20" slogan, and the library's strongest pitch (antd-grade DX for Table / Select / Combobox / Date Picker, on the shadcn base, distributed as copy-in registry source) was never stated.

## Changes

- **Components table now covers all 17 components** (was 10). The four state-machine components — Table, Select, Combobox, Date Picker — lead the list behind a short antd-parity lead-in; the thin wrappers follow. Each "what it collapses" line was checked against the actual `registry/ui/*.tsx` props (no invented APIs; Tabs items now use `trigger`, not `label`).
- **New Hooks table**: `use-delay-loading`, `use-select-items`, `use-select-loader`.
- **Before/after code block** near Quickstart (Card, primitive nesting vs one flat-prop tag) to surface the core value proposition at a glance.
- **Design Philosophy rewritten** to the ADR-0004 external version — three points: thin wrappers stay minimal while state-machine components approach antd; the onboarding concept count is frozen; the primitive door is unlocked.
- `README.zh-CN.md` rewritten section-by-section to mirror the English version.

## Verification

- Every install command (`@easy-shadcn/<name>`) and component name reconciled 1:1 against `registry.json`'s `name` fields.
- Every prop named in the copy was confirmed to exist in the corresponding source file.
- `git diff --name-only origin/main` shows only `README.md` and `README.zh-CN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)