### PR TITLE
feat(docs): llms.txt outputs and AI-agent installation guide

### DIFF
--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -1,0 +1,16 @@
+import { getLLMText } from "@/lib/get-llm-text";
+import { source } from "@/lib/source";
+
+// cached forever
+export const revalidate = false;
+
+export async function GET() {
+  const scan = source.getPages().map(getLLMText);
+  const scanned = await Promise.all(scan);
+
+  return new Response(scanned.join("\n\n"), {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}

--- a/app/llms.mdx/[[...slug]]/route.ts
+++ b/app/llms.mdx/[[...slug]]/route.ts
@@ -1,0 +1,27 @@
+import { notFound } from "next/navigation";
+import { getLLMText } from "@/lib/get-llm-text";
+import { source } from "@/lib/source";
+
+// cached forever
+export const revalidate = false;
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ slug?: string[] }> }
+) {
+  const { slug } = await params;
+  const page = source.getPage(slug);
+  if (!page) {
+    notFound();
+  }
+
+  return new Response(await getLLMText(page), {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+    },
+  });
+}
+
+export function generateStaticParams() {
+  return source.generateParams();
+}

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,0 +1,13 @@
+import { llms } from "fumadocs-core/source";
+import { source } from "@/lib/source";
+
+// cached forever
+export const revalidate = false;
+
+export function GET() {
+  return new Response(llms(source).index(), {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}

--- a/content/docs/installation.mdx
+++ b/content/docs/installation.mdx
@@ -55,3 +55,36 @@ Zero configuration, but you'll need to type the full URL every time.
 - **Short commands**: Once configured, the install experience matches the official shadcn flow.
 
 > `@easy-shadcn` is **not** a globally registered namespace — it's just a local alias in your `components.json` that points to this registry's URL template. You can rename the alias, but the registry's internal `registryDependencies` declare `@easy-shadcn/...`, so renaming it requires updating those references too. Keeping the default is recommended.
+
+## AI Agents / MCP
+
+If you use an AI coding agent (Claude Code, Cursor, VS Code, Codex, opencode), the shadcn CLI ships an **MCP server** that lets the agent browse and install `@easy-shadcn/*` components on your behalf — no need to paste URLs or component names by hand.
+
+First make sure the `@easy-shadcn` registry is configured in your `components.json` (see [Recommended](#recommended-configure-the-easy-shadcn-namespace) above). Then register the MCP server for your client:
+
+```shell
+pnpm dlx shadcn@latest mcp init --client claude
+# other clients: --client cursor | vscode | codex | opencode
+```
+
+Once connected, ask the agent in natural language, for example:
+
+> "List the components available in the @easy-shadcn registry, then add the modal and card."
+
+The agent reads your `components.json`, resolves the `@easy-shadcn` namespace, and runs the install for you — cross-component dependencies are resolved automatically.
+
+For agents that consume plain text, this site also publishes the whole documentation set as LLM-friendly Markdown:
+
+- [`/llms.txt`](https://easy-shadcn.vercel.app/llms.txt) — an index of every page with a one-line description.
+- [`/llms-full.txt`](https://easy-shadcn.vercel.app/llms-full.txt) — the full docs concatenated as a single Markdown file.
+- Append `.md` to any docs URL for that page's raw Markdown, e.g. `/docs/components/card.md`.
+
+## Updating Components
+
+easy-shadcn follows the shadcn **copy-in** model: `add` copies the component source into your project, so upgrading means re-running `add` with `--overwrite`:
+
+```shell
+pnpm dlx shadcn@latest add @easy-shadcn/card --overwrite
+```
+
+> `--overwrite` replaces the local files, so any changes you made to the copied component will be lost. Commit or `git diff` first to review — if you've customized a component, reapply your edits after updating (or extend it from a wrapper in your own directory instead of editing the copy in place).

--- a/lib/get-llm-text.ts
+++ b/lib/get-llm-text.ts
@@ -1,0 +1,15 @@
+import type { InferPageType } from "fumadocs-core/source";
+import type { source } from "@/lib/source";
+
+/**
+ * Format a single docs page as plain Markdown for LLM consumption.
+ *
+ * Requires `includeProcessedMarkdown` to be enabled in `source.config.ts`.
+ */
+export async function getLLMText(page: InferPageType<typeof source>) {
+  const processed = await page.data.getText("processed");
+
+  return `# ${page.data.title} (${page.url})
+
+${processed}`;
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,19 @@ const nextConfig: NextConfig = {
     ],
   },
   reactCompiler: true,
+  // Serve raw Markdown per page for AI agents: /docs/<path>.md(x) -> /llms.mdx/<path>
+  async rewrites() {
+    return [
+      {
+        source: "/docs/:path*.mdx",
+        destination: "/llms.mdx/:path*",
+      },
+      {
+        source: "/docs/:path*.md",
+        destination: "/llms.mdx/:path*",
+      },
+    ];
+  },
 };
 
 export default withMDX(nextConfig);

--- a/source.config.ts
+++ b/source.config.ts
@@ -2,6 +2,12 @@ import { defineConfig, defineDocs } from "fumadocs-mdx/config";
 
 export const docs = defineDocs({
   dir: "content/docs",
+  docs: {
+    // Enables `page.data.getText("processed")` for llms-full.txt / raw markdown output.
+    postprocess: {
+      includeProcessedMarkdown: true,
+    },
+  },
 });
 
 export default defineConfig();


### PR DESCRIPTION
## What

Make the documentation site consumable by AI coding agents, using Fumadocs' official LLM integration APIs.

### New routes (`app/`)
- **`/llms.txt`** — sitemap-style index (title + one-line description per page), generated by `llms(source).index()` from `fumadocs-core/source`.
- **`/llms-full.txt`** — every page concatenated as clean Markdown, via a `getLLMText` helper mapped over `source.getPages()`.
- **`/docs/<path>.md`** and **`/docs/<path>.mdx`** — per-page raw Markdown, served by a `/llms.mdx/[[...slug]]` route handler behind a `next.config.ts` rewrite.

### Supporting changes
- `lib/get-llm-text.ts` — formats a page as `# Title (url)\n\n<processed markdown>`.
- `source.config.ts` — enables `docs.postprocess.includeProcessedMarkdown` so `page.data.getText("processed")` returns clean Markdown (required by the helper).
- `next.config.ts` — `rewrites()` mapping `/docs/:path*.md(x)` to the markdown route.

### Docs (`content/docs/installation.mdx`)
- **AI Agents / MCP** — how to register the shadcn MCP server (`pnpm dlx shadcn@latest mcp init --client claude`) so agents can browse and install `@easy-shadcn/*` components; links to `/llms.txt` and `/llms-full.txt`.
- **Updating Components** — the copy-in upgrade flow (`add ... --overwrite`) with a warning to `git diff` first.

## Verification
- `pnpm build` passes; all routes prerender (`/llms.txt`, `/llms-full.txt`, `/llms.mdx/[[...slug]]` for all 20 pages).
- `pnpm exec ultracite check` clean on the new/modified source files.
- `next start` + `curl`: `/llms.txt` and `/llms-full.txt` return `200 text/plain`; `/docs/components/card.md` and `.mdx` return `200 text/markdown` (rewrite confirmed).

## Notes
- No new dependencies (uses existing `fumadocs-core` / `fumadocs-mdx`).
- `lib/get-llm-text.ts` was force-added: the repo's `.gitignore` has a broad bare `lib` pattern (intended for package build output); the existing tracked `lib/*.ts` files were force-added the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)