### PR TITLE
docs: record English-only built-in text decision, add localizing guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,7 @@ modal.hide()
 - ❌ `slots` 对象（MUI 风格）
 - ❌ "在 A 和 B 中间插入自定义节点"的 prop
 - ❌ 违反规则 A/B 的 prop：薄封装里为边缘场景开的口子，或任何抬高"基础用例概念数"的 prop
+- ❌ locale / i18n 机制：内置文案一律英文，英文默认值是 API 的一部分。copy-in 分发下本地化是使用侧的事——传 props、改本地拷贝、或包一层固化默认，见 installation 文档的 Localizing Built-in Text 章节
 
 遇到此类需求，答案永远是："**去用 `components/ui/*` 原语**"。
 

--- a/content/docs/installation.mdx
+++ b/content/docs/installation.mdx
@@ -88,3 +88,20 @@ pnpm dlx shadcn@latest add @easy-shadcn/card --overwrite
 ```
 
 > `--overwrite` replaces the local files, so any changes you made to the copied component will be lost. Commit or `git diff` first to review — if you've customized a component, reapply your edits after updating (or extend it from a wrapper in your own directory instead of editing the copy in place).
+
+## Localizing Built-in Text
+
+Components ship with English defaults — `"Loading…"`, `"No data"`, `"Pick an option"`, `"OK"` / `"Cancel"`. There is deliberately no locale mechanism: the code is copied into your repo, so localization is a consumer-side concern. Three ways, from ad-hoc to app-wide:
+
+1. **Pass props.** Every built-in string has a prop: `loadingMessage`, `emptyMessage`, `placeholder`, `confirmText` / `cancelText`, and so on.
+2. **Edit your copy.** Change the default right in the file `add` dropped into your project. Note that upgrading with `--overwrite` resets it.
+3. **Wrap and re-export** (recommended for app-wide defaults). Bake your defaults into a wrapper you own — upgrades never touch it:
+
+```tsx
+// components/app-table.tsx
+import { Table, type TableProps } from "@/components/easy/table"
+
+export function AppTable<T>(props: TableProps<T>) {
+  return <Table emptyMessage="暂无数据" loadingMessage="加载中…" {...props} />
+}
+```


### PR DESCRIPTION
## What

- **AGENTS.md**: 在"拒绝扩大 API 的诱惑"清单加一条永久禁止项——locale / i18n 机制。内置文案一律英文，英文默认值是 API 的一部分；copy-in 分发下本地化是使用侧的事。
- **installation.mdx**: 新增 "Localizing Built-in Text" 章节，把三条使用侧路径写成文档化模式：传 props / 改本地拷贝 / 包一层固化默认（附 AppTable 示例）。

## Why

防止未来贡献者（或 coding agent）好心提 locale prop / ConfigProvider；把"缺失的功能"变成"文档化的模式"。决策讨论见维护者拍板：内置文案全英文，仓库不做 i18n 机制。

🤖 Generated with [Claude Code](https://claude.com/claude-code)